### PR TITLE
Add notion_id and fields to plant_varieties

### DIFF
--- a/db/migrate/20260222163900_add_notion_fields_to_plant_varieties.rb
+++ b/db/migrate/20260222163900_add_notion_fields_to_plant_varieties.rb
@@ -1,0 +1,10 @@
+class AddNotionFieldsToPlantVarieties < ActiveRecord::Migration[8.0]
+  def change
+    add_column :plant_varieties, :notion_id, :string
+    add_column :plant_varieties, :notion_created_at, :datetime
+    add_column :plant_varieties, :notion_updated_at, :datetime
+    add_index :plant_varieties, :notion_id, unique: true
+
+    change_column_null :plant_varieties, :species_id, true
+  end
+end

--- a/db/migrate/20260222164000_add_notion_variety_fields.rb
+++ b/db/migrate/20260222164000_add_notion_variety_fields.rb
@@ -1,0 +1,12 @@
+class AddNotionVarietyFields < ActiveRecord::Migration[8.0]
+  def change
+    add_column :plant_varieties, :common_names_fr, :string, default: "", null: false
+    add_column :plant_varieties, :description, :text, default: "", null: false
+    add_column :plant_varieties, :characteristics, :jsonb, default: [], null: false
+    add_column :plant_varieties, :labels, :jsonb, default: [], null: false
+    add_column :plant_varieties, :usages, :jsonb, default: [], null: false
+    add_column :plant_varieties, :fertility, :string, default: "", null: false
+    add_column :plant_varieties, :juice_quality, :string, default: "", null: false
+    add_column :plant_varieties, :publish_on_website, :boolean, default: false, null: false
+  end
+end


### PR DESCRIPTION
Fixes PlantRecord import (234 errors due to missing notion_id on plant_varieties).

- Adds notion_id, notion_created_at, notion_updated_at to plant_varieties
- Adds Notion-specific fields (common_names_fr, description, characteristics, labels, usages, fertility, juice_quality, publish_on_website)
- Makes species_id nullable (some varieties have no linked species in Notion)