### PR TITLE
fix: Sentry P2 — N+1 academy calendar + nil project notes channel

### DIFF
--- a/app/channels/project_notes_channel.rb
+++ b/app/channels/project_notes_channel.rb
@@ -7,8 +7,11 @@ class ProjectNotesChannel < ApplicationCable::Channel
   end
 
   def receive(data)
+    project = @project || PoleProject.find_by(id: params[:project_id])
+    return unless project
+
     ActionCable.server.broadcast(
-      "project_notes_#{@project.id}",
+      "project_notes_#{project.id}",
       data
     )
   end

--- a/app/controllers/api/v1/academy_controller.rb
+++ b/app/controllers/api/v1/academy_controller.rb
@@ -631,7 +631,7 @@ module Api
           trainingId: training.id.to_s,
           title: training.title,
           status: training.status,
-          sessions: training.sessions.order(:start_date).map do |session|
+          sessions: training.sessions.sort_by(&:start_date).map do |session|
             {
               sessionId: session.id.to_s,
               startDate: session.start_date.iso8601,


### PR DESCRIPTION
## Summary

- **N+1 fix**: `serialize_calendar_entry` was calling `training.sessions.order(:start_date)` which bypasses the preloaded association cache and fires a query per training. Replaced with `training.sessions.sort_by(&:start_date)` to sort in Ruby using already-loaded data.
- **NoMethodError fix**: `ProjectNotesChannel#receive` used `@project.id` directly, which raises if `@project` is nil (ActionCable reconnection edge case where `subscribed` doesn't re-run). Added a guard to re-fetch from `params[:project_id]` if `@project` is nil, and returns early if still not found.

## Test plan

- [ ] Verify academy calendar endpoint returns correct session order without extra queries
- [ ] Simulate ActionCable reconnection to confirm notes channel no longer raises `NoMethodError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)