### PR TITLE
Fix plant card roots partial for French root_system values

### DIFF
--- a/app/helpers/plant_cards_helper.rb
+++ b/app/helpers/plant_cards_helper.rb
@@ -189,9 +189,19 @@ module PlantCardsHelper
     "plant_cards/silhouettes/#{habit}"
   end
 
+  ROOT_SYSTEM_NORMALIZE = {
+    'Pivotante' => 'taproot',
+    'Fasciculées' => 'fibrous',
+    'Traçante' => 'spreading',
+    'Drageonnante' => 'spreading',
+    'Flat' => 'shallow',
+    'mixte' => 'default'
+  }.freeze
+  ROOT_PARTIALS = %w[deep fibrous shallow spreading taproot].freeze
+
   def roots_partial(species)
-    rs = species.root_system.to_s
-    return 'plant_cards/roots/default' if rs.empty?
+    rs = ROOT_SYSTEM_NORMALIZE[species.root_system.to_s] || species.root_system.to_s
+    return 'plant_cards/roots/default' unless ROOT_PARTIALS.include?(rs)
     "plant_cards/roots/#{rs}"
   end
 


### PR DESCRIPTION
## Summary

Follow-up to #29 — fixes `ActionView::MissingTemplate` when rendering a plant card whose `root_system` is a French label that doesn't match any partial filename.

`PlantCardsHelper#roots_partial` now normalizes legacy French values (`Pivotante`, `Fasciculées`, `Traçante`, `Drageonnante`, `Flat`, `mixte`) to the available partial names (`taproot`, `fibrous`, `spreading`, `shallow`, `default`), and falls back to `default` for any unknown value.

## Test Plan

- [ ] Hit `/plants/species/:id/card` for a species whose `root_system` was previously failing — confirm 200 and correct silhouette
- [ ] Hit a card whose `root_system` is one of the existing English keys (`fibrous`, `deep`, `spreading`) — confirm unchanged behavior
- [ ] Confirm cards still render for species with `root_system: nil`

🤖 Generated with [Claude Code](https://claude.com/claude-code)