### PR TITLE
Academy : accès My Semisto pour des contacts non inscrits

### DIFF
--- a/app/controllers/api/v1/academy_controller.rb
+++ b/app/controllers/api/v1/academy_controller.rb
@@ -657,11 +657,11 @@ module Api
       end
 
       def training_params
-        params.permit(:title, :status, :price, :deposit_amount, :vat_rate, :max_participants, :requires_accommodation, :description, :coordinator_note, checklist_items: [], checked_items: [])
+        params.permit(:title, :status, :price, :deposit_amount, :vat_rate, :max_participants, :requires_accommodation, :description, :coordinator_note, checklist_items: [], checked_items: [], access_contact_ids: [])
       end
 
       def training_update_params
-        params.permit(:title, :status, :price, :deposit_amount, :vat_rate, :max_participants, :requires_accommodation, :description, :coordinator_note, :training_type_id, checklist_items: [], checked_items: [])
+        params.permit(:title, :status, :price, :deposit_amount, :vat_rate, :max_participants, :requires_accommodation, :description, :coordinator_note, :training_type_id, checklist_items: [], checked_items: [], access_contact_ids: [])
       end
 
       def session_params
@@ -773,6 +773,8 @@ module Api
           coordinatorNote: item.coordinator_note,
           checklistItems: item.checklist_items,
           checkedItems: item.checked_items,
+          accessContactIds: item.access_contact_ids,
+          accessContacts: access_contacts_for(item.access_contact_ids),
           album: item.album ? serialize_training_album(item.album) : nil,
           participantCategories: item.participant_categories.order(:position).map { |c|
             { id: c.id.to_s, label: c.label, price: c.price.to_f, maxSpots: c.max_spots,
@@ -785,6 +787,18 @@ module Api
           createdAt: item.created_at.iso8601,
           updatedAt: item.updated_at.iso8601
         }
+      end
+
+      # Resolves contact IDs (granted My Semisto access) to lightweight {id,name,email}.
+      # Memoizes contacts across the request to avoid an N+1 in the overview action
+      # (which serializes every training).
+      def access_contacts_for(ids)
+        return [] if ids.blank?
+        @contacts_by_id ||= {}
+        missing = ids.map(&:to_s) - @contacts_by_id.keys
+        Contact.where(id: missing).each { |c| @contacts_by_id[c.id.to_s] = c } if missing.any?
+        ids.filter_map { |id| @contacts_by_id[id.to_s] }
+           .map { |c| { id: c.id.to_s, name: c.display_name, email: c.email.to_s } }
       end
 
       def serialize_training_album(album)

--- a/app/controllers/api/v1/my_semisto_controller.rb
+++ b/app/controllers/api/v1/my_semisto_controller.rb
@@ -99,9 +99,7 @@ module Api
       # ── Academy API ──
 
       def academy_trainings
-        registrations = contact_registrations.includes(training: [:training_type, :sessions])
-        training_ids = registrations.map(&:training_id).uniq
-        trainings = Academy::Training.where(id: training_ids).includes(:training_type, :sessions)
+        trainings = Academy::Training.where(id: accessible_training_ids).includes(:training_type, :sessions)
 
         render json: {
           trainings: trainings.map { |t| serialize_portal_training(t) }
@@ -190,6 +188,21 @@ module Api
                  email: current_contact.email&.downcase)
       end
 
+      # Training IDs where this contact was explicitly granted access (formateurs,
+      # coordinateurs…) without being a registered participant.
+      def access_granted_training_ids
+        Academy::Training
+          .where(deleted_at: nil)
+          .where("access_contact_ids @> ?", [current_contact.id.to_s].to_json)
+          .pluck(:id)
+      end
+
+      # All trainings this contact may view in the portal: registered participations
+      # plus explicit access grants.
+      def accessible_training_ids
+        (contact_registrations.pluck(:training_id) + access_granted_training_ids).uniq
+      end
+
       def find_contact_registration!
         registration = contact_registrations.find_by(training_id: params[:training_id])
         unless registration
@@ -221,12 +234,11 @@ module Api
       end
 
       def find_contact_training!
-        registration = contact_registrations.find_by(training_id: params[:training_id])
-        unless registration
+        unless accessible_training_ids.include?(params[:training_id].to_i)
           render json: { error: "Formation introuvable" }, status: :not_found
           return nil
         end
-        Academy::Training.includes(:training_type, :sessions, :documents).find(registration.training_id)
+        Academy::Training.includes(:training_type, :sessions, :documents).find(params[:training_id])
       end
 
       def contact_avatar_url(contact)

--- a/app/frontend/components/academy/TrainingFormModal.jsx
+++ b/app/frontend/components/academy/TrainingFormModal.jsx
@@ -1,8 +1,18 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { Search, X, Loader2, UserPlus } from 'lucide-react'
 import SimpleEditor from '@/components/SimpleEditor'
+import { apiRequest } from '../../lib/api'
 
 const inputBase =
   'w-full px-4 py-2.5 rounded-xl bg-stone-50 border border-stone-200 text-stone-900 placeholder:text-stone-400 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-[#B01A19]/30 focus:border-[#B01A19]'
+
+function debounce(fn, ms) {
+  let timer
+  return (...args) => {
+    clearTimeout(timer)
+    timer = setTimeout(() => fn(...args), ms)
+  }
+}
 
 export function TrainingFormModal({ training, trainingTypes, onSubmit, onCancel, busy = false }) {
   const isEdit = Boolean(training)
@@ -42,6 +52,15 @@ export function TrainingFormModal({ training, trainingTypes, onSubmit, onCancel,
     return []
   })
   const [error, setError] = useState(null)
+
+  // My Semisto access grants: contacts who may view this training + its documents
+  // in the portal without being registered participants.
+  const [accessContacts, setAccessContacts] = useState(training?.accessContacts ?? [])
+  const [accessQuery, setAccessQuery] = useState('')
+  const [accessSuggestions, setAccessSuggestions] = useState([])
+  const [showAccessSuggestions, setShowAccessSuggestions] = useState(false)
+  const [accessSearchLoading, setAccessSearchLoading] = useState(false)
+  const accessSearchRef = useRef(null)
 
   const activeCategories = categories.filter((c) => !c._destroy && c.label.trim())
   const showPacks = activeCategories.length >= 2
@@ -83,6 +102,60 @@ export function TrainingFormModal({ training, trainingTypes, onSubmit, onCancel,
     document.addEventListener('keydown', handleEscape)
     return () => document.removeEventListener('keydown', handleEscape)
   }, [onCancel])
+
+  // Close access-contact suggestions on click outside
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (accessSearchRef.current && !accessSearchRef.current.contains(e.target)) {
+        setShowAccessSuggestions(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const searchAccessContacts = useCallback(
+    debounce(async (query) => {
+      if (!query || query.length < 2) {
+        setAccessSuggestions([])
+        setShowAccessSuggestions(false)
+        return
+      }
+      setAccessSearchLoading(true)
+      try {
+        const res = await apiRequest(`/api/v1/lab/contacts?q=${encodeURIComponent(query)}&contact_type=person`)
+        const items = res.items || []
+        setAccessSuggestions(items)
+        setShowAccessSuggestions(items.length > 0)
+      } catch {
+        setAccessSuggestions([])
+      } finally {
+        setAccessSearchLoading(false)
+      }
+    }, 300),
+    []
+  )
+
+  const handleAccessQueryChange = (value) => {
+    setAccessQuery(value)
+    searchAccessContacts(value)
+  }
+
+  const addAccessContact = (contact) => {
+    setAccessContacts((prev) =>
+      prev.some((c) => String(c.id) === String(contact.id))
+        ? prev
+        : [...prev, { id: String(contact.id), name: contact.name || 'Sans nom', email: contact.email || '' }]
+    )
+    setAccessQuery('')
+    setAccessSuggestions([])
+    setShowAccessSuggestions(false)
+  }
+
+  const removeAccessContact = (id) => {
+    setAccessContacts((prev) => prev.filter((c) => String(c.id) !== String(id)))
+  }
 
   const computePackSavings = (pack) => {
     const individualTotal = activeCategories.reduce((sum, cat) => {
@@ -151,6 +224,7 @@ export function TrainingFormModal({ training, trainingTypes, onSubmit, onCancel,
         coordinator_note: coordinatorNote === '<p></p>' ? '' : coordinatorNote,
         participant_categories: categoriesPayload,
         packs: packsPayload.length > 0 ? packsPayload : undefined,
+        access_contact_ids: accessContacts.map((c) => String(c.id)),
       })
     } catch (err) {
       setError(err.message || "Erreur lors de l'enregistrement")
@@ -607,6 +681,88 @@ export function TrainingFormModal({ training, trainingTypes, onSubmit, onCancel,
                     onUpdate={setCoordinatorNote}
                     minHeight="100px"
                   />
+                </div>
+
+                {/* My Semisto access */}
+                <div>
+                  <label className="block text-sm font-semibold text-stone-700 mb-2">
+                    Accès My Semisto
+                  </label>
+                  <p className="text-xs text-stone-400 mb-3">
+                    Ces personnes pourront consulter cette activité et ses documents depuis leur espace
+                    My Semisto, sans être inscrites comme participantes (formateurs, coordinateur…).
+                  </p>
+
+                  {/* Selected contacts as chips */}
+                  {accessContacts.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mb-3">
+                      {accessContacts.map((contact) => (
+                        <span
+                          key={contact.id}
+                          className="inline-flex items-center gap-2 rounded-full bg-[#B01A19]/10 pl-3 pr-2 py-1 text-sm font-medium text-[#B01A19]"
+                        >
+                          <span className="truncate max-w-[200px]">
+                            {contact.name}
+                            {contact.email ? (
+                              <span className="text-[#B01A19]/60"> · {contact.email}</span>
+                            ) : null}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => removeAccessContact(contact.id)}
+                            className="rounded-full p-0.5 hover:bg-[#B01A19]/20 transition-colors"
+                            title="Retirer l'accès"
+                          >
+                            <X className="w-3.5 h-3.5" />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Search input + suggestions */}
+                  <div className="relative" ref={accessSearchRef}>
+                    <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400 pointer-events-none" />
+                    <input
+                      type="text"
+                      value={accessQuery}
+                      onChange={(e) => handleAccessQueryChange(e.target.value)}
+                      onFocus={() => accessSuggestions.length > 0 && setShowAccessSuggestions(true)}
+                      placeholder="Rechercher un contact par nom ou email…"
+                      className={`${inputBase} pl-10`}
+                    />
+                    {accessSearchLoading && (
+                      <Loader2 className="absolute right-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400 animate-spin" />
+                    )}
+
+                    {showAccessSuggestions && accessSuggestions.length > 0 && (
+                      <div className="absolute z-10 left-0 right-0 mt-1 max-h-56 overflow-y-auto rounded-xl border border-stone-200 bg-white shadow-lg">
+                        {accessSuggestions.map((contact) => {
+                          const alreadyAdded = accessContacts.some((c) => String(c.id) === String(contact.id))
+                          return (
+                            <button
+                              key={contact.id}
+                              type="button"
+                              disabled={alreadyAdded}
+                              onClick={() => addAccessContact(contact)}
+                              className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-stone-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                            >
+                              <UserPlus className="w-4 h-4 text-stone-400 shrink-0" />
+                              <span className="flex-1 min-w-0">
+                                <span className="block text-sm font-medium text-stone-900 truncate">
+                                  {contact.name || 'Sans nom'}
+                                </span>
+                                {contact.email && (
+                                  <span className="block text-xs text-stone-500 truncate">{contact.email}</span>
+                                )}
+                              </span>
+                              {alreadyAdded && <span className="text-xs text-stone-400">Ajouté</span>}
+                            </button>
+                          )
+                        })}
+                      </div>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>

--- a/db/migrate/20260522120000_add_access_contact_ids_to_academy_trainings.rb
+++ b/db/migrate/20260522120000_add_access_contact_ids_to_academy_trainings.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddAccessContactIdsToAcademyTrainings < ActiveRecord::Migration[8.1]
+  def change
+    # Contact IDs (stored as strings, like trainer_ids/assistant_ids) explicitly
+    # granted My Semisto access to this training without being registered participants.
+    add_column :academy_trainings, :access_contact_ids, :jsonb, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_20_195158) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_22_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -219,6 +219,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_20_195158) do
   end
 
   create_table "academy_trainings", force: :cascade do |t|
+    t.jsonb "access_contact_ids", default: [], null: false
     t.jsonb "checked_items", default: [], null: false
     t.jsonb "checklist_items", default: [], null: false
     t.text "coordinator_note", default: "", null: false

--- a/test/integration/my_semisto_test.rb
+++ b/test/integration/my_semisto_test.rb
@@ -170,6 +170,56 @@ class MySemistoTest < ActionDispatch::IntegrationTest
     assert body["trainings"].any? { |t| t["title"] == "Formation email" }
   end
 
+  # ── Explicit My Semisto access (no registration) ──
+
+  test "GET /api/v1/my/academy lists trainings the contact was explicitly granted" do
+    trainer = Contact.create!(contact_type: "person", name: "Formateur Léa", email: "lea@example.com")
+    granted_training = Academy::Training.create!(
+      training_type: @training_type,
+      title: "Formation des formateurs",
+      status: "in_preparation",
+      access_contact_ids: [trainer.id.to_s]
+    )
+
+    sign_in_contact(trainer)
+
+    get "/api/v1/my/academy", as: :json
+    assert_response :success
+    body = JSON.parse(response.body)
+    titles = body["trainings"].map { |t| t["title"] }
+    assert_includes titles, "Formation des formateurs"
+    # The granted contact has no registration, so only the granted training shows up
+    assert_equal [granted_training.id.to_s], body["trainings"].map { |t| t["id"] }
+  end
+
+  test "GET /api/v1/my/academy/:id returns detail + documents for a granted contact" do
+    trainer = Contact.create!(contact_type: "person", name: "Formateur Léa", email: "lea@example.com")
+    @training.update!(access_contact_ids: [trainer.id.to_s])
+    Academy::TrainingDocument.create!(
+      training: @training,
+      name: "Guide formateur",
+      url: "https://example.com/guide.pdf",
+      uploaded_at: Time.current
+    )
+
+    sign_in_contact(trainer)
+
+    get "/api/v1/my/academy/#{@training.id}", as: :json
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal @training.id.to_s, body["id"]
+    assert_equal 1, body["documents"].length
+    assert_equal "Guide formateur", body["documents"][0]["name"]
+  end
+
+  test "GET /api/v1/my/academy/:id returns 404 for a contact neither registered nor granted" do
+    stranger = Contact.create!(contact_type: "person", name: "Inconnu", email: "stranger@example.com")
+    sign_in_contact(stranger)
+
+    get "/api/v1/my/academy/#{@training.id}", as: :json
+    assert_response :not_found
+  end
+
   # ── Carpooling API ──
 
   test "GET /api/v1/my/academy/:id/carpooling returns carpooling data" do
@@ -372,13 +422,16 @@ class MySemistoTest < ActionDispatch::IntegrationTest
   private
 
   def auth_headers
-    # Set up session by going through the verify endpoint first
+    sign_in_contact(@contact)
+    {}
+  end
+
+  def sign_in_contact(contact)
     token = Rails.application.message_verifier(:contact_login).generate(
-      { contact_id: @contact.id },
+      { contact_id: contact.id },
       purpose: :contact_login,
       expires_in: 24.hours
     )
     get "/api/v1/my/auth/verify", params: { token: token }
-    {}
   end
 end


### PR DESCRIPTION
## Contexte

Aujourd'hui, dans le portail **My Semisto** (authentifié par `Contact` via magic-link), un contact ne voit une activité Academy et ses documents que s'il possède une `TrainingRegistration` rattachée à cette activité. On veut pouvoir donner accès à d'autres personnes (formateurs, coordinateur) **sans qu'elles soient inscrites comme participantes**.

Point clé : « membre My Semisto » = **Contact** (le portail authentifie des Contacts, pas des `Member` internes). On réutilise le pattern existant des listes d'IDs de contacts en jsonb (`trainer_ids` / `assistant_ids`).

## Changements

- **Migration** : colonne `access_contact_ids` (jsonb, default `[]`) sur `academy_trainings`.
- **Admin (`academy_controller`)** : `access_contact_ids` permis en create/update ; `serialize_training` expose `accessContactIds` + `accessContacts` (`{id,name,email}` résolus via un helper mémoïsé pour éviter le N+1 dans `overview`).
- **Portail (`my_semisto_controller`)** : nouveaux helpers `access_granted_training_ids` / `accessible_training_ids` (union inscriptions + accès explicites), utilisés par `academy_trainings` et `find_contact_training!`. Le covoiturage reste volontairement réservé aux inscrits.
- **UI (`TrainingFormModal`)** : section « Accès My Semisto » avec recherche de contacts debouncée (réutilise le pattern de `RegistrationFormModal`, endpoint `/api/v1/lab/contacts?q=…&contact_type=person`) et chips de contacts sélectionnés.
- **Skill API** : `academy.md` documente le nouveau champ et l'effet sur l'accès portail.

## Décisions produit (validées avec Michael)

1. Pool = **tout contact de l'annuaire** (recherche autocomplete).
2. Emplacement = **modale d'édition** de l'activité.
3. **Liste explicite uniquement** (pas d'auto-accès pour les formateurs de session).

## Tests

- `my_semisto_test.rb` : un contact non inscrit mais autorisé voit l'activité (liste) + détail/documents ; un contact ni inscrit ni autorisé reçoit 404. ✅ 24 runs
- Non-régression : `academy_management_test.rb` + `academy_categories_test.rb` ✅ 99 runs
- `bin/vite build` compile la modale sans erreur.

⚠️ Vérification navigateur non réalisée : le port Vite 3036 était occupé par un autre projet local, empêchant l'hydratation. À tester manuellement : Academy → activité → Modifier → « Accès My Semisto » → ajouter un contact → enregistrer → connecter ce contact sur `/my`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)