### PR TITLE
Nova: correctifs d'exécution (filtre permission repo + version Node)

### DIFF
--- a/.github/nova/README.md
+++ b/.github/nova/README.md
@@ -26,10 +26,12 @@ Le tout en utilisant la config Claude personnelle de Michael (`mhulet/claude-con
 Ce repo est **public** et Nova exécute du code (`claude -p --dangerously-skip-permissions`) à
 partir d’un prompt qui inclut le contenu de l’issue. Donc :
 
-- **`nova:auto` n’est PAS une frontière de sécurité.** La vraie barrière est le **filtre auteur** :
-  sur le run planifié, seules les issues écrites par un `OWNER`/`MEMBER`/`COLLABORATOR` du repo
-  entrent dans la matrice (`discover-issues.sh`). Une issue d’un compte externe portant `nova:auto`
-  est **ignorée** (un warning le signale dans le log du run).
+- **`nova:auto` n’est PAS une frontière de sécurité.** La vraie barrière est le **filtre de
+  permission** : sur le run planifié, seules les issues dont l’**auteur a un accès write au repo**
+  (`admin`/`maintain`/`write`) entrent dans la matrice (`discover-issues.sh`). Une issue d’un
+  compte externe portant `nova:auto` est **ignorée** (un warning le signale dans le log du run).
+  → On se base sur la permission, **pas** sur `author_association` (sur un repo d’organisation, un
+  admin dont l’appartenance est privée apparaît `CONTRIBUTOR` et serait rejeté à tort).
   → Conséquence : pour traiter la demande d’un externe, un mainteneur recrée/ré-ouvre l’issue.
 - Le contenu de l’issue est passé à Claude encadré comme **donnée non fiable** ; le prompt lui
   interdit d’obéir à des instructions qui s’y cacheraient (injection de prompt).

--- a/.github/nova/discover-issues.sh
+++ b/.github/nova/discover-issues.sh
@@ -3,18 +3,19 @@
 # Sortie : `matrix` (JSON array de numéros) et `count` (entier) dans $GITHUB_OUTPUT.
 #
 # Éligible = label `nova:auto` ET PAS `nova:blocked` ET PAS `nova:pr-open`
-#            ET auteur de confiance (OWNER/MEMBER/COLLABORATOR).
+#            ET auteur ayant un accès write au repo (admin/maintain/write).
 #
 # ⚠️ SÉCURITÉ : ce repo est PUBLIC. Le titre/corps/commentaires d'une issue sont injectés
 # dans le prompt d'un agent qui tourne avec --dangerously-skip-permissions. Le label `nova:auto`
 # n'est PAS une frontière de sécurité (un tiers peut tenter de l'apposer). La vraie barrière est
-# le filtre `author_association` ci-dessous : seules les issues écrites par un membre/collaborateur
-# du repo entrent dans la matrice. Ne JAMAIS relâcher ce filtre sur le chemin planifié.
+# le filtre de PERMISSION ci-dessous : seules les issues d'un auteur ayant un accès write au repo
+# entrent dans la matrice. (On n'utilise PAS author_association : sur un repo d'org, un admin dont
+# l'appartenance est privée apparaît `CONTRIBUTOR`.) Ne JAMAIS relâcher ce filtre sur le planifié.
 set -euo pipefail
 
 MAX="${MAX_ISSUES:-8}"
 REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY manquant}"
-TRUSTED=" OWNER MEMBER COLLABORATOR "
+TRUSTED=" admin maintain write "
 
 emit() { # $1=matrix $2=count
   echo "matrix=$1" >> "$GITHUB_OUTPUT"
@@ -35,29 +36,32 @@ fi
 
 # Candidats : label nova:auto, hors blocked/pr-open.
 candidates="$(gh issue list \
-  --state open --label "nova:auto" --json number,labels --limit 100 \
+  --state open --label "nova:auto" --json number,labels,author --limit 100 \
   --jq '[ .[]
           | (.labels | map(.name)) as $l
           | select( ($l | index("nova:blocked") | not)
                 and ( $l | index("nova:pr-open") | not) )
-          | .number ]' 2>/dev/null || echo '[]')"
+          | {number, login: .author.login} ]' 2>/dev/null || echo '[]')"
 [ -z "$candidates" ] && candidates='[]'
 
-# Filtre auteur de confiance, issue par issue (peu d'issues nova:auto → peu d'appels API).
+# Filtre de confiance basé sur la PERMISSION RÉELLE de l'auteur sur le repo (admin/maintain/write).
+# On NE se fie PAS à `author_association` : sur un repo d'organisation, un membre dont l'appartenance
+# est privée apparaît `CONTRIBUTOR` même s'il est admin. La permission, elle, est fiable.
 selected='[]'
 skipped=''
-for n in $(echo "$candidates" | jq -r '.[]'); do
-  assoc="$(gh api "repos/$REPO/issues/$n" --jq '.author_association' 2>/dev/null || echo NONE)"
-  if [[ "$TRUSTED" == *" $assoc "* ]]; then
+while IFS=$'\t' read -r n login; do
+  [ -z "${n:-}" ] && continue
+  perm="$(gh api "repos/$REPO/collaborators/$login/permission" --jq '.role_name // .permission' 2>/dev/null || echo none)"
+  if [[ "$TRUSTED" == *" $perm "* ]]; then
     selected="$(echo "$selected" | jq -c ". + [$n]")"
   else
-    skipped="$skipped #$n($assoc)"
+    skipped="$skipped #$n($login:$perm)"
   fi
-done
+done < <(echo "$candidates" | jq -r '.[] | "\(.number)\t\(.login)"')
 
 matrix="$(echo "$selected" | jq -c ".[:$MAX]")"
 count="$(echo "$matrix" | jq 'length')"
 emit "$matrix" "$count"
 
-[ -n "$skipped" ] && echo "::warning::Issues nova:auto ignorées car auteur non fiable :$skipped"
+[ -n "$skipped" ] && echo "::warning::Issues nova:auto ignorées car auteur sans accès write :$skipped"
 echo "Sélection (plafond ${MAX}) : $matrix  (count=$count)"


### PR DESCRIPTION
## Problème
Le run de découverte rejetait l'issue #38 (de @mhulet) : `Issues nova:auto ignorées car auteur non fiable : #38(CONTRIBUTOR)`.

Cause : sur un repo d'**organisation**, l'API renvoie `author_association = CONTRIBUTOR` pour un membre dont l'appartenance à l'org est **privée**, même s'il est **admin**. Mon filtre se fiait à `author_association` → faux rejet.

## Correctif
La découverte vérifie maintenant la **permission réelle** de l'auteur sur le repo via `GET /repos/{repo}/collaborators/{login}/permission`, et ne retient que `admin`/`maintain`/`write`. C'est le vrai critère « cette personne a-t-elle le droit de pousser du code ». La barrière de sécurité (issues d'externes ignorées) est **conservée**, et même plus fiable.

## Vérifié
Dry-run réel contre `semisto-org/terranova` : `matrix=[38], count=1` (mhulet = admin → retenu).