### PR TITLE
Nova: extraire la version Node du .tool-versions (corrige setup-node)

### DIFF
--- a/.github/workflows/nova-nightly.yml
+++ b/.github/workflows/nova-nightly.yml
@@ -82,10 +82,14 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Read Node version from .tool-versions
+        id: nodever
+        run: echo "version=$(grep -E '^nodejs ' .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".tool-versions"
+          node-version: ${{ steps.nodever.outputs.version }}
           cache: yarn
 
       - name: Enable Yarn


### PR DESCRIPTION
## Problème
`actions/setup-node` n'extrait pas la ligne `nodejs` d'un `.tool-versions` asdf multi-outils : il prend tout le fichier comme numéro de version → `Unable to find Node version 'ruby 3.3.10 nodejs 24.13.0'`.

(Ce correctif avait été poussé sur la branche de la PR #52 après son merge/close, il n'était donc pas arrivé sur `main` — d'où cette PR dédiée.)

## Correctif
On lit la version nous-mêmes (`grep '^nodejs' .tool-versions | awk '{print $2}'` = `24.13.0`) et on la passe à `node-version`.

## Vérifié
Extraction testée localement (`24.13.0`), YAML valide.