### PR TITLE
Méthodo · Analyse — sections génériques (#64 #68 #69 #70)

### DIFF
--- a/app/controllers/api/v1/design_studio_controller.rb
+++ b/app/controllers/api/v1/design_studio_controller.rb
@@ -696,6 +696,25 @@ module Api
         head :no_content
       end
 
+      # Sections d'analyse génériques (formulaires structurés par sous-section méthodo).
+      def analysis_sections
+        project = find_project
+        map = project.analysis_sections.each_with_object({}) { |s, acc| acc[s.node_key] = s.data }
+        render json: map
+      end
+
+      def upsert_analysis_section
+        project = find_project
+        section = project.analysis_sections.find_or_initialize_by(node_key: params[:node_key])
+        section.data = params[:data].respond_to?(:to_unsafe_h) ? params[:data].to_unsafe_h : (params[:data] || {})
+
+        if section.save
+          render json: { node_key: section.node_key, data: section.data }
+        else
+          render json: { errors: section.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
       def create_quote
         project = find_project
 

--- a/app/frontend/design-studio/components/AnalysisForms.tsx
+++ b/app/frontend/design-studio/components/AnalysisForms.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useState } from 'react'
+import { apiRequest } from '../../lib/api'
+
+type SectionData = Record<string, unknown>
+
+// Hook générique : lit/écrit le `data` JSONB d'une sous-section d'analyse.
+function useAnalysisSection(projectId: string, nodeKey: string): [SectionData, (next: SectionData) => void] {
+  const [data, setData] = useState<SectionData>({})
+
+  useEffect(() => {
+    apiRequest(`/api/v1/design/${projectId}/analysis-sections`)
+      .then((map) => setData(map[nodeKey] ?? {}))
+      .catch(() => {})
+  }, [projectId, nodeKey])
+
+  const save = useCallback(
+    (next: SectionData) => {
+      setData(next)
+      apiRequest(`/api/v1/design/${projectId}/analysis-section`, {
+        method: 'PATCH',
+        body: JSON.stringify({ node_key: nodeKey, data: next }),
+      }).catch(() => {})
+    },
+    [projectId, nodeKey],
+  )
+
+  return [data, save]
+}
+
+interface Field {
+  key: string
+  label: string
+}
+
+// Formulaire générique : une zone de texte par champ, sauvegarde au blur.
+function FieldsForm({ projectId, nodeKey, fields }: { projectId: string; nodeKey: string; fields: Field[] }) {
+  const [data, save] = useAnalysisSection(projectId, nodeKey)
+
+  return (
+    <div className="mt-3 space-y-2 rounded-xl bg-stone-50 p-3">
+      {fields.map((f) => (
+        <label key={f.key} className="block">
+          <span className="mb-1 block text-[12px] font-medium text-stone-600">{f.label}</span>
+          <textarea
+            defaultValue={(data[f.key] as string) ?? ''}
+            onBlur={(e) => {
+              if (e.target.value !== ((data[f.key] as string) ?? '')) save({ ...data, [f.key]: e.target.value })
+            }}
+            rows={2}
+            className="w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-[13px] text-stone-700 focus:border-[#AFBD00] focus:ring-1 focus:ring-[#AFBD00]"
+          />
+        </label>
+      ))}
+    </div>
+  )
+}
+
+// #64 — Tri des données
+export function TriDonnees({ projectId }: { projectId: string }) {
+  return (
+    <FieldsForm
+      projectId={projectId}
+      nodeKey="analyse-evaluation/tri-des-donnees"
+      fields={[
+        { key: 'porteur', label: 'Porteur — éléments retenus' },
+        { key: 'projet', label: 'Projet — éléments retenus' },
+        { key: 'ecosysteme', label: 'Écosystème — éléments retenus' },
+      ]}
+    />
+  )
+}
+
+// #68 — Échelle de temps
+export function EchelleTemps({ projectId }: { projectId: string }) {
+  return (
+    <FieldsForm
+      projectId={projectId}
+      nodeKey="analyse-evaluation/echelle-de-temps"
+      fields={[
+        { key: 'historique', label: 'Historique du site' },
+        { key: 'planning_design', label: 'Planning — design' },
+        { key: 'planning_mise_en_oeuvre', label: 'Planning — mise en œuvre' },
+        { key: 'planning_maintenance', label: 'Planning — maintenance' },
+      ]}
+    />
+  )
+}
+
+// #69 — Ressources & facteurs limitants
+export function RessourcesLimites({ projectId }: { projectId: string }) {
+  return (
+    <FieldsForm
+      projectId={projectId}
+      nodeKey="analyse-evaluation/ressources-facteurs-limitants"
+      fields={[
+        { key: 'temps', label: 'Temps' },
+        { key: 'argent', label: 'Argent' },
+        { key: 'ressources_humaines', label: 'Ressources humaines' },
+        { key: 'matieres', label: 'Matières disponibles (sur site / hors site)' },
+      ]}
+    />
+  )
+}
+
+// #70 — Systémique en place : fleur permaculturelle (auto-évaluation) + carte mentale
+const FLEUR_DOMAINES = [
+  'Terre & nature',
+  'Habitat & construction',
+  'Outils & technologie',
+  'Culture & éducation',
+  'Santé & spiritualité',
+  'Finance & économie',
+  'Patrimoine & communauté',
+]
+
+export function SystemiqueEnPlace({ projectId }: { projectId: string }) {
+  const nodeKey = 'analyse-evaluation/systemique-en-place'
+  const [data, save] = useAnalysisSection(projectId, nodeKey)
+  const fleur = (data.fleur as Record<string, number>) ?? {}
+
+  return (
+    <div className="mt-3 space-y-3 rounded-xl bg-stone-50 p-3">
+      <div>
+        <p className="mb-1 text-[12px] font-medium text-stone-600">Fleur permaculturelle — maturité (0–5)</p>
+        <div className="space-y-1.5">
+          {FLEUR_DOMAINES.map((domaine) => (
+            <div key={domaine} className="flex items-center gap-2">
+              <span className="w-44 shrink-0 text-[12px] text-stone-600">{domaine}</span>
+              <input
+                type="range"
+                min={0}
+                max={5}
+                value={fleur[domaine] ?? 0}
+                onChange={(e) => save({ ...data, fleur: { ...fleur, [domaine]: Number(e.target.value) } })}
+                className="flex-1 accent-[#AFBD00]"
+              />
+              <span className="w-4 text-right text-[12px] text-stone-500">{fleur[domaine] ?? 0}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <label className="block">
+        <span className="mb-1 block text-[12px] font-medium text-stone-600">Carte mentale (lien ou notes)</span>
+        <textarea
+          defaultValue={(data.carte_mentale as string) ?? ''}
+          onBlur={(e) => {
+            if (e.target.value !== ((data.carte_mentale as string) ?? '')) save({ ...data, carte_mentale: e.target.value })
+          }}
+          rows={2}
+          className="w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-[13px] text-stone-700 focus:border-[#AFBD00] focus:ring-1 focus:ring-[#AFBD00]"
+        />
+      </label>
+    </div>
+  )
+}

--- a/app/frontend/design-studio/components/MethodologyCockpit.tsx
+++ b/app/frontend/design-studio/components/MethodologyCockpit.tsx
@@ -14,6 +14,7 @@ import { ToolboxPanel } from './ToolboxPanel'
 import { ObservationNotes } from './ObservationNotes'
 import { Interview } from './Interview'
 import { SoilSurvey } from './SoilSurvey'
+import { TriDonnees, EchelleTemps, RessourcesLimites, SystemiqueEnPlace } from './AnalysisForms'
 
 // --- Types (miroir du payload GET /api/v1/design/:id/methodology) ---
 
@@ -291,6 +292,18 @@ export function MethodologyCockpit({ projectId, onOpenTool }: MethodologyCockpit
                 )}
                 {activeStep.key === 'observation' && sub.key === 'releve' && (
                   <SoilSurvey projectId={projectId} />
+                )}
+                {activeStep.key === 'analyse-evaluation' && sub.key === 'tri-des-donnees' && (
+                  <TriDonnees projectId={projectId} />
+                )}
+                {activeStep.key === 'analyse-evaluation' && sub.key === 'echelle-de-temps' && (
+                  <EchelleTemps projectId={projectId} />
+                )}
+                {activeStep.key === 'analyse-evaluation' && sub.key === 'ressources-facteurs-limitants' && (
+                  <RessourcesLimites projectId={projectId} />
+                )}
+                {activeStep.key === 'analyse-evaluation' && sub.key === 'systemique-en-place' && (
+                  <SystemiqueEnPlace projectId={projectId} />
                 )}
               </section>
             ))}

--- a/app/models/design/analysis_section.rb
+++ b/app/models/design/analysis_section.rb
@@ -1,0 +1,25 @@
+module Design
+  # Données structurées libres rattachées à une sous-section de la méthodologie
+  # (formulaires d'analyse : tri des données, échelle de temps, ressources, systémique…).
+  # Table sparse : une ligne par sous-section effectivement remplie. Le `data` JSONB porte
+  # la forme propre à chaque sous-section (validée côté frontend), le backend reste générique.
+  class AnalysisSection < ApplicationRecord
+    self.table_name = 'design_analysis_sections'
+
+    belongs_to :project, class_name: 'Design::Project', foreign_key: :project_id
+
+    validates :node_key, presence: true
+    validates :node_key, uniqueness: { scope: :project_id }
+    validate :node_key_is_defined
+
+    private
+
+    # Le node_key doit correspondre à une sous-section connue de la méthodologie.
+    def node_key_is_defined
+      return if node_key.blank?
+      return if Design::Methodology.valid_node_key?(node_key)
+
+      errors.add(:node_key, "n'existe pas dans la méthodologie : #{node_key}")
+    end
+  end
+end

--- a/app/models/design/project.rb
+++ b/app/models/design/project.rb
@@ -48,6 +48,7 @@ module Design
     has_many :observation_notes, class_name: 'Design::ObservationNote', foreign_key: :project_id, dependent: :destroy
     has_one :interview, class_name: 'Design::Interview', foreign_key: :project_id, dependent: :destroy
     has_many :soil_samples, class_name: 'Design::SoilSample', foreign_key: :project_id, dependent: :destroy
+    has_many :analysis_sections, class_name: 'Design::AnalysisSection', foreign_key: :project_id, dependent: :destroy
     has_one_attached :releve_plan
     has_one :album, as: :albumable, dependent: :destroy
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -510,6 +510,8 @@ Rails.application.routes.draw do
       post "design/:project_id/soil-samples", to: "design_studio#create_soil_sample"
       patch "design/soil-samples/:sample_id", to: "design_studio#update_soil_sample"
       delete "design/soil-samples/:sample_id", to: "design_studio#destroy_soil_sample"
+      get "design/:project_id/analysis-sections", to: "design_studio#analysis_sections"
+      patch "design/:project_id/analysis-section", to: "design_studio#upsert_analysis_section"
       post "design/:project_id/quotes", to: "design_studio#create_quote"
       patch "design/quotes/:quote_id", to: "design_studio#update_quote"
       delete "design/quotes/:quote_id", to: "design_studio#destroy_quote"

--- a/db/migrate/20260604170000_create_design_analysis_sections.rb
+++ b/db/migrate/20260604170000_create_design_analysis_sections.rb
@@ -1,0 +1,16 @@
+class CreateDesignAnalysisSections < ActiveRecord::Migration[8.1]
+  def change
+    create_table :design_analysis_sections do |t|
+      t.references :project, null: false,
+                             foreign_key: { to_table: :design_projects },
+                             index: true
+      t.string :node_key, null: false
+      t.jsonb :data, null: false, default: {}
+
+      t.timestamps
+    end
+
+    add_index :design_analysis_sections, %i[project_id node_key], unique: true,
+                                                                  name: 'index_design_analysis_sections_on_project_and_node'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_04_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_04_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -581,6 +581,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_160000) do
     t.date "start_date", null: false
     t.string "status", default: "upcoming", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "design_analysis_sections", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.jsonb "data", default: {}, null: false
+    t.string "node_key", null: false
+    t.bigint "project_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id", "node_key"], name: "index_design_analysis_sections_on_project_and_node", unique: true
+    t.index ["project_id"], name: "index_design_analysis_sections_on_project_id"
   end
 
   create_table "design_annotations", force: :cascade do |t|
@@ -2600,6 +2610,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_160000) do
   add_foreign_key "contacts", "contacts", column: "organization_id"
   add_foreign_key "credentials", "guilds"
   add_foreign_key "credentials", "members", column: "created_by_id"
+  add_foreign_key "design_analysis_sections", "design_projects", column: "project_id"
   add_foreign_key "design_annotations", "design_projects", column: "project_id"
   add_foreign_key "design_client_contributions", "design_projects", column: "project_id"
   add_foreign_key "design_follow_up_visits", "design_projects", column: "project_id"

--- a/test/integration/design_analysis_sections_test.rb
+++ b/test/integration/design_analysis_sections_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class DesignAnalysisSectionsTest < ActionDispatch::IntegrationTest
+  setup do
+    [Design::AnalysisSection, Design::Project].each(&:delete_all)
+
+    @project = Design::Project.create!(
+      name: 'Projet analyse test',
+      client_id: 'client-1',
+      client_name: 'Client Test',
+      client_email: 'client@test.com',
+      city: 'Yvoir',
+      area: 1000,
+      phase: 'offre',
+      status: 'pending',
+      project_manager_id: 'member-1'
+    )
+  end
+
+  test 'PATCH upserts a section then GET returns it keyed by node' do
+    patch "/api/v1/design/#{@project.id}/analysis-section",
+          params: { node_key: 'analyse-evaluation/ressources-facteurs-limitants',
+                    data: { temps: '2 jours/semaine', argent: '5000€' } },
+          as: :json
+    assert_response :success
+
+    get "/api/v1/design/#{@project.id}/analysis-sections", as: :json
+    assert_response :success
+    body = response.parsed_body
+    assert_equal '2 jours/semaine', body['analyse-evaluation/ressources-facteurs-limitants']['temps']
+  end
+
+  test 'upsert is idempotent and merges data' do
+    2.times do
+      patch "/api/v1/design/#{@project.id}/analysis-section",
+            params: { node_key: 'analyse-evaluation/echelle-de-temps', data: { historique: 'ancien verger' } },
+            as: :json
+    end
+    assert_equal 1, @project.analysis_sections.where(node_key: 'analyse-evaluation/echelle-de-temps').count
+  end
+
+  test 'unknown node_key is rejected' do
+    patch "/api/v1/design/#{@project.id}/analysis-section",
+          params: { node_key: 'foo/bar', data: {} }, as: :json
+    assert_response :unprocessable_entity
+  end
+end


### PR DESCRIPTION
Traite 4 issues de la Vague 2 via un mécanisme générique `Design::AnalysisSection` (data jsonb par sous-section, validé contre la méthodo) + formulaires branchés au cockpit.

- #64 Tri des données · #68 Échelle de temps · #69 Ressources & facteurs limitants · #70 Systémique en place (fleur permaculturelle + carte mentale).
- API : `GET analysis-sections`, `PATCH analysis-section`. Test 3/5 ; tsc via CI.

Reste de la Vague 2 : cartes secteurs/zones (#65/#66) + biome (#67), traitement dédié à suivre.

Closes #64, #68, #69, #70.