### PR TITLE
Méthodo · Analyse — Biome (#67)

### DIFF
--- a/app/frontend/design-studio/components/AnalysisForms.tsx
+++ b/app/frontend/design-studio/components/AnalysisForms.tsx
@@ -70,6 +70,21 @@ export function TriDonnees({ projectId }: { projectId: string }) {
   )
 }
 
+// #67 — Biome
+export function Biome({ projectId }: { projectId: string }) {
+  return (
+    <FieldsForm
+      projectId={projectId}
+      nodeKey="analyse-evaluation/biome"
+      fields={[
+        { key: 'climat_rusticite', label: 'Climat / zone de rusticité' },
+        { key: 'succession_especes_cles', label: 'Succession écologique — espèces clés' },
+        { key: 'sous_sol', label: 'Sous-sol' },
+      ]}
+    />
+  )
+}
+
 // #68 — Échelle de temps
 export function EchelleTemps({ projectId }: { projectId: string }) {
   return (

--- a/app/frontend/design-studio/components/MethodologyCockpit.tsx
+++ b/app/frontend/design-studio/components/MethodologyCockpit.tsx
@@ -14,7 +14,7 @@ import { ToolboxPanel } from './ToolboxPanel'
 import { ObservationNotes } from './ObservationNotes'
 import { Interview } from './Interview'
 import { SoilSurvey } from './SoilSurvey'
-import { TriDonnees, EchelleTemps, RessourcesLimites, SystemiqueEnPlace } from './AnalysisForms'
+import { TriDonnees, Biome, EchelleTemps, RessourcesLimites, SystemiqueEnPlace } from './AnalysisForms'
 
 // --- Types (miroir du payload GET /api/v1/design/:id/methodology) ---
 
@@ -295,6 +295,9 @@ export function MethodologyCockpit({ projectId, onOpenTool }: MethodologyCockpit
                 )}
                 {activeStep.key === 'analyse-evaluation' && sub.key === 'tri-des-donnees' && (
                   <TriDonnees projectId={projectId} />
+                )}
+                {activeStep.key === 'analyse-evaluation' && sub.key === 'biome' && (
+                  <Biome projectId={projectId} />
                 )}
                 {activeStep.key === 'analyse-evaluation' && sub.key === 'echelle-de-temps' && (
                   <EchelleTemps projectId={projectId} />


### PR DESCRIPTION
Traite #67 (Vague 2). Formulaire Biome (climat/rusticité, succession + espèces clés, sous-sol) via `AnalysisSection`, branché au cockpit. tsc via CI.

Closes #67.