### PR TITLE
Méthodo · Mise en œuvre & Évolution (#81–85)

### DIFF
--- a/app/frontend/design-studio/components/EvolutionForms.tsx
+++ b/app/frontend/design-studio/components/EvolutionForms.tsx
@@ -1,0 +1,47 @@
+import { FieldsForm } from './AnalysisForms'
+
+// #83 — Boucles de rétroaction (la Co-gestion reste accessible en deep-link)
+export function BouclesRetroaction({ projectId }: { projectId: string }) {
+  return (
+    <FieldsForm
+      projectId={projectId}
+      nodeKey="evolution/observation-retroaction"
+      fields={[{ key: 'boucles_retroaction', label: 'Boucles de rétroaction observées (post-implantation)' }]}
+    />
+  )
+}
+
+// #84 — Visualisation des impacts (graphes santé/production : enrichissement possible depuis la Co-gestion)
+export function VisualisationImpacts({ projectId }: { projectId: string }) {
+  return (
+    <FieldsForm
+      projectId={projectId}
+      nodeKey="evolution/visualisation"
+      fields={[{ key: 'impacts', label: 'Impacts à moyen et long terme' }]}
+    />
+  )
+}
+
+// #85 — Anticipation & accélération
+export function Anticipation({ projectId }: { projectId: string }) {
+  return (
+    <FieldsForm
+      projectId={projectId}
+      nodeKey="evolution/anticipation"
+      fields={[{ key: 'adaptation', label: 'Adaptation (agilité, re-design)' }]}
+    />
+  )
+}
+
+export function AccelererProcessus({ projectId }: { projectId: string }) {
+  return (
+    <FieldsForm
+      projectId={projectId}
+      nodeKey="evolution/accelerer-processus"
+      fields={[
+        { key: 'redesign', label: 'Redesign écosystémique' },
+        { key: 'upscaling', label: 'Upscaling' },
+      ]}
+    />
+  )
+}

--- a/app/frontend/design-studio/components/MethodologyCockpit.tsx
+++ b/app/frontend/design-studio/components/MethodologyCockpit.tsx
@@ -26,6 +26,8 @@ import {
   PlansModelisation,
   PaletteGuidee,
 } from './DesignForms'
+import { Phaser, GestionProjet } from './MiseEnOeuvreForms'
+import { BouclesRetroaction, VisualisationImpacts, Anticipation, AccelererProcessus } from './EvolutionForms'
 
 // --- Types (miroir du payload GET /api/v1/design/:id/methodology) ---
 
@@ -355,6 +357,24 @@ export function MethodologyCockpit({ projectId, onOpenTool, coordinates }: Metho
                 )}
                 {activeStep.key === 'design' && sub.key === 'selection-palette' && (
                   <PaletteGuidee projectId={projectId} />
+                )}
+                {activeStep.key === 'mise-en-oeuvre-maintenance' && sub.key === 'phaser' && (
+                  <Phaser projectId={projectId} />
+                )}
+                {activeStep.key === 'mise-en-oeuvre-maintenance' && sub.key === 'gestion-du-projet' && (
+                  <GestionProjet projectId={projectId} />
+                )}
+                {activeStep.key === 'evolution' && sub.key === 'observation-retroaction' && (
+                  <BouclesRetroaction projectId={projectId} />
+                )}
+                {activeStep.key === 'evolution' && sub.key === 'visualisation' && (
+                  <VisualisationImpacts projectId={projectId} />
+                )}
+                {activeStep.key === 'evolution' && sub.key === 'anticipation' && (
+                  <Anticipation projectId={projectId} />
+                )}
+                {activeStep.key === 'evolution' && sub.key === 'accelerer-processus' && (
+                  <AccelererProcessus projectId={projectId} />
                 )}
               </section>
             ))}

--- a/app/frontend/design-studio/components/MiseEnOeuvreForms.tsx
+++ b/app/frontend/design-studio/components/MiseEnOeuvreForms.tsx
@@ -1,0 +1,72 @@
+import { FieldsForm, useAnalysisSection } from './AnalysisForms'
+
+const SUCCESSION_STRATEGIES = [
+  { key: 'tout-en-une-fois', label: 'Tout en une fois (Antoine Talin)' },
+  { key: 'successionnelle', label: 'Successionnelle (Desjours, van Eck)' },
+  { key: 'incrementielle', label: 'Incrémentielle (Martin Crawford)' },
+]
+
+// #81 — Phasage & stratégies de succession
+export function Phaser({ projectId }: { projectId: string }) {
+  const [data, save] = useAnalysisSection(projectId, 'mise-en-oeuvre-maintenance/phaser')
+  const strategy = (data.strategy as string) ?? ''
+
+  return (
+    <div className="mt-3 space-y-3 rounded-xl bg-stone-50 p-3">
+      <div>
+        <p className="mb-1.5 text-[12px] font-medium text-stone-600">Stratégie de succession</p>
+        <div className="space-y-1">
+          {SUCCESSION_STRATEGIES.map((s) => (
+            <label key={s.key} className="flex items-center gap-2 text-[13px] text-stone-700">
+              <input
+                type="radio"
+                name={`succession-${projectId}`}
+                checked={strategy === s.key}
+                onChange={() => save({ ...data, strategy: s.key })}
+                className="accent-[#AFBD00]"
+              />
+              {s.label}
+            </label>
+          ))}
+        </div>
+      </div>
+      <label className="block">
+        <span className="mb-1 block text-[12px] font-medium text-stone-600">Phasage (échelle de permanence)</span>
+        <textarea
+          defaultValue={(data.phasage as string) ?? ''}
+          onBlur={(e) => e.target.value !== ((data.phasage as string) ?? '') && save({ ...data, phasage: e.target.value })}
+          rows={2}
+          className="w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-[13px] text-stone-700 focus:border-[#AFBD00] focus:ring-1 focus:ring-[#AFBD00]"
+        />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-[12px] font-medium text-stone-600">Productions combinées (canopée ouverte / intermédiaire / mature)</span>
+        <textarea
+          defaultValue={(data.productions_combinees as string) ?? ''}
+          onBlur={(e) =>
+            e.target.value !== ((data.productions_combinees as string) ?? '') &&
+            save({ ...data, productions_combinees: e.target.value })
+          }
+          rows={2}
+          className="w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-[13px] text-stone-700 focus:border-[#AFBD00] focus:ring-1 focus:ring-[#AFBD00]"
+        />
+      </label>
+    </div>
+  )
+}
+
+// #82 — Gestion du projet (planning/budget restent accessibles via Tasks/Timesheets/Bucket en deep-link)
+export function GestionProjet({ projectId }: { projectId: string }) {
+  return (
+    <FieldsForm
+      projectId={projectId}
+      nodeKey="mise-en-oeuvre-maintenance/gestion-du-projet"
+      fields={[
+        { key: 'gouvernance', label: 'Gouvernance' },
+        { key: 'communication', label: 'Communication' },
+        { key: 'budget_notes', label: "Budget (achats, main d'œuvre, autoproduction de plants)" },
+        { key: 'entretien', label: 'Entretien (STUN, taille, récolte)' },
+      ]}
+    />
+  )
+}


### PR DESCRIPTION
Traite les **Vagues 5 et 6** via `AnalysisSection` (frontend) : phasage & succession, gestion du projet, boucles de rétroaction, visualisation des impacts, anticipation & re-design. Tasks/Timesheets/Budget et Co-gestion restent réutilisés en deep-link. tsc via CI.

**Boucle le parcours méthodologique complet (6 étapes).**

Closes #81, #82, #83, #84, #85.