### PR TITLE
fix(my-semisto): lien album photo sur activité à session unique

### DIFF
--- a/app/frontend/pages/MySemisto/TrainingDetail.jsx
+++ b/app/frontend/pages/MySemisto/TrainingDetail.jsx
@@ -201,6 +201,9 @@ export default function TrainingDetail() {
               index={sessions.indexOf(featuredSession)}
               docs={sessionDocMap[featuredSession.id] || []}
               hideCarpoolLink={activityPast}
+              trainingId={trainingId}
+              canEdit={training.canUpload}
+              onChanged={() => loadTraining()}
             />
           ) : null}
 
@@ -270,7 +273,7 @@ function ProgressStrip({ pastCount, total }) {
 
 // The centerpiece: a featured session (next upcoming, ongoing, or — for
 // single-session activities — that one session even if past), fully expanded.
-function NextSessionHero({ session, index, docs, hideCarpoolLink = false }) {
+function NextSessionHero({ session, index, docs, hideCarpoolLink = false, trainingId, canEdit, onChanged }) {
   const ongoing = isSessionOngoing(session)
   const past = isSessionPast(session)
   const accent = past ? COLOR_PAST : COLOR_UPCOMING
@@ -329,6 +332,14 @@ function NextSessionHero({ session, index, docs, hideCarpoolLink = false }) {
 
         {/* Practical info */}
         <SessionPractical session={session} />
+
+        {/* Google Photos album — link + trainer edit affordance */}
+        <SessionPhotoAlbum
+          trainingId={trainingId}
+          session={session}
+          canEdit={canEdit}
+          onSaved={onChanged}
+        />
 
         {/* Session documents */}
         {docs.length > 0 && (


### PR DESCRIPTION
## Contexte
Sur la page d'une activité Academy (MySemisto, ex `/academy/20`), quand l'activité n'a **qu'une seule session**, celle-ci s'affiche dans le bloc « hero » en haut (`NextSessionHero`). Le lien pour **ajouter l'album Google Photos** y était manquant.

## Cause
`SessionPhotoAlbum` n'était rendu que dans `SessionRow`, partie de la timeline « Toutes les sessions » — affichée uniquement quand `sessions.length > 1`. Une activité mono-session passe par `NextSessionHero`, qui ne l'embarquait pas.

## Correction
`NextSessionHero` rend désormais `SessionPhotoAlbum` après les infos pratiques, avec `trainingId` / `canEdit` / `onChanged`, exactement comme `SessionRow`. Backend déjà prêt (champ `photo_album_url`, endpoint PATCH, sérialisation `photoAlbumUrl`).

## Vérification
- ✅ esbuild : le JSX compile proprement
- ✅ Import `SessionPhotoAlbum` présent, props en scope au call site
- ⚠️ Pas de vérif navigateur e2e (nécessitait une session formateur sur une activité mono-session). À confirmer après déploiement : ouvrir une activité à session unique en formateur → le bouton « Ajouter l'album photo » apparaît sous les infos pratiques du bloc du haut.

1 fichier · +12/-1 · aucune migration.