### PR TITLE
feat: notifications polymorphes + activity_events — service de génération (#104)

### DIFF
--- a/app/jobs/task_due_soon_notification_job.rb
+++ b/app/jobs/task_due_soon_notification_job.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Notification d'échéance proche (#104) — tourne chaque matin via solid_queue
+# (config/recurring.yml). Décisions actées (10/06) : J-1 (la veille de
+# l'échéance), et la tâche doit avoir un assigné pour avoir un destinataire.
+#
+# Idempotent : un rejeu le même jour ne recrée ni événement ni notification
+# (garde sur l'ActivityEvent du jour + index unique du fan-out).
+class TaskDueSoonNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Task.where(due_date: Date.tomorrow)
+        .where.not(status: "completed")
+        .where.not(assignee_id: nil)
+        .find_each do |task|
+      next if already_recorded_today?(task)
+
+      NotificationService.record!(
+        action: "task_due_soon", subject: task,
+        kind_for: ->(_) { "due_soon" }
+      )
+    end
+  end
+
+  private
+
+  def already_recorded_today?(task)
+    ActivityEvent.exists?(
+      action: "task_due_soon", subject: task,
+      created_at: Time.current.all_day
+    )
+  end
+end

--- a/app/models/activity_event.rb
+++ b/app/models/activity_event.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Événement d'activité (#104, amendement 11/06) — 1 ligne par action, sans
+# destinataire. C'est la source de vérité du flux ambiant (#110) ; les
+# Notification (#105) en dérivent via NotificationService.
+#
+# `actor` est optionnel : certains événements n'ont pas de « qui » (décision
+# actée sur #110). `projectable` est le projet parent au sens large, pour le
+# filtrage cross-projets du flux Activity.
+class ActivityEvent < ApplicationRecord
+  belongs_to :actor, class_name: "Member", optional: true
+  belongs_to :subject, polymorphic: true
+  belongs_to :projectable, polymorphic: true, optional: true
+
+  has_many :notifications, dependent: :destroy
+
+  validates :action, presence: true
+
+  scope :recent_first, -> { order(created_at: :desc) }
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -29,6 +29,12 @@ class Comment < ApplicationRecord
   after_save :sync_mentions!, if: :saved_change_to_body?
   # Abonnement auto (#103) : commenter = suivre l'objet commenté.
   after_create :auto_subscribe_author
+  # Notifications (#104) — en after_save déclaré APRÈS sync_mentions! pour que
+  # les mentions soient extraites et les mentionnés abonnés avant le fan-out.
+  # (after_create s'exécuterait AVANT les after_save → mentions invisibles.)
+  after_save :record_creation_activity, if: :previously_new_record?
+
+  has_many :activity_events, as: :subject, dependent: :destroy
 
   scope :ordered, -> { order(created_at: :asc) }
 
@@ -45,6 +51,21 @@ class Comment < ApplicationRecord
     return unless commentable.respond_to?(:auto_subscribe!)
 
     commentable.auto_subscribe!(author)
+  end
+
+  # Un seul ActivityEvent par commentaire ; le fan-out distingue les kinds :
+  # `mention` pour les membres mentionnés, `comment` pour les autres abonnés.
+  def record_creation_activity
+    mentioned_ids = mentions.pluck(:member_id)
+    subscriber_ids = commentable.respond_to?(:notifiable_member_ids) ? commentable.notifiable_member_ids : []
+
+    NotificationService.record!(
+      action: "comment_created",
+      subject: self,
+      actor: author,
+      recipients: subscriber_ids | mentioned_ids,
+      kind_for: ->(recipient_id) { mentioned_ids.include?(recipient_id) ? "mention" : "comment" }
+    )
   end
 
   def sync_mentions!

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,7 @@ class Event < ApplicationRecord
   has_many :attendees, through: :event_attendees, source: :member
   has_one :album, as: :albumable, dependent: :destroy
   has_many :comments, as: :commentable, dependent: :destroy
+  has_many :activity_events, as: :subject, dependent: :destroy
 
   validates :title, :event_type, :start_date, :end_date, presence: true
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Notification interne (#104) — toujours dérivée d'un ActivityEvent par
+# NotificationService (jamais créée à la main : l'événement d'abord, le
+# fan-out ensuite). Consommée par la boîte Hey! (#105).
+#
+# KINDS n'est pas une liste fermée validée : ajouter un type de notification
+# (ex. réponse de check-in en Phase 3) ne doit pas exiger de refonte —
+# critère « conçu ouvert » de l'issue.
+class Notification < ApplicationRecord
+  belongs_to :recipient, class_name: "Member"
+  belongs_to :activity_event
+  belongs_to :notifiable, polymorphic: true
+  belongs_to :actor, class_name: "Member", optional: true
+
+  validates :kind, presence: true
+
+  scope :unread, -> { where(read_at: nil) }
+  scope :recent_first, -> { order(created_at: :desc) }
+
+  def read?
+    read_at.present?
+  end
+
+  def mark_read!
+    update!(read_at: Time.current) unless read?
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -37,6 +37,12 @@ class Task < ApplicationRecord
   before_save :stamp_completion, if: :will_save_change_to_status?
   # Abonnement auto (#103) : devenir assigné = suivre la tâche.
   after_save :auto_subscribe_assignee, if: :saved_change_to_assignee_id?
+  # Notifications (#104) — déclarées APRÈS l'abonnement auto pour que
+  # l'assigné soit déjà abonné au moment du fan-out.
+  after_save :record_assignment_activity, if: :saved_change_to_assignee_id?
+  after_save :record_ping_activity, if: :saved_change_to_pinged_at?
+
+  has_many :activity_events, as: :subject, dependent: :destroy
 
   # Une tâche ne peut être assignée qu'à un membre de l'équipe du projet auquel
   # elle appartient. La règle vit dans le modèle (et non seulement dans un
@@ -61,6 +67,24 @@ class Task < ApplicationRecord
 
   def auto_subscribe_assignee
     auto_subscribe!(assignee) if assignee_id.present?
+  end
+
+  def record_assignment_activity
+    return if assignee_id.blank?
+
+    NotificationService.record!(
+      action: "task_assigned", subject: self, actor: assigned_by,
+      kind_for: ->(_) { "assignment" }
+    )
+  end
+
+  def record_ping_activity
+    return if pinged_at.blank? # retrait d'un coucou : pas une notification
+
+    NotificationService.record!(
+      action: "task_pinged", subject: self, actor: pinged_by,
+      kind_for: ->(_) { "ping" }
+    )
   end
 
   def stamp_assignment

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Service unique de génération (#104) — point d'entrée de TOUTE la plomberie
+# async calme. Séquence invariante (décision d'architecture du 11/06) :
+#
+#   1. Écrire l'ActivityEvent (flux ambiant #110 — toujours, même sans abonné).
+#   2. Fan-out des Notification vers les destinataires (boîte Hey! #105).
+#
+# Destinataires par défaut : `subject.notifiable_member_ids` (#103 — abonnés
+# actifs, mute projet respecté, suivi explicite prime). L'acteur n'est JAMAIS
+# notifié. Idempotence du fan-out garantie par l'index unique
+# (recipient, activity_event) + `create_or_find_by`.
+#
+# Conçu ouvert : un nouveau type d'événement (ex. réponse de check-in,
+# Phase 3) = un appel `NotificationService.record!` supplémentaire — aucune
+# refonte. `kind_for` permet des kinds par destinataire (ex. `mention` pour
+# les membres mentionnés, `comment` pour les autres abonnés du même événement).
+class NotificationService
+  # action       — verbe de l'événement (ex. "task_assigned", "comment_created")
+  # subject      — l'objet de l'événement (porte aussi le lien cliquable)
+  # actor        — le membre à l'origine (nil accepté, cf. décision #110)
+  # recipients   — ids explicites ; défaut = subject.notifiable_member_ids
+  # kind_for     — lambda(recipient_id) → kind ; défaut = action
+  # notifiable   — objet pointé par la notification ; défaut = subject
+  def self.record!(action:, subject:, actor: nil, recipients: nil, kind_for: nil, notifiable: nil)
+    event = ActivityEvent.create!(
+      action: action,
+      subject: subject,
+      actor: actor,
+      projectable: resolve_projectable(subject)
+    )
+
+    recipient_ids = recipients || default_recipients(subject)
+    recipient_ids = recipient_ids.uniq - [actor&.id].compact
+
+    notifiable ||= subject
+    recipient_ids.each do |recipient_id|
+      Notification.create_or_find_by!(recipient_id: recipient_id, activity_event_id: event.id) do |n|
+        n.notifiable = notifiable
+        n.actor = actor
+        n.kind = kind_for ? kind_for.call(recipient_id) : action
+      end
+    end
+
+    event
+  end
+
+  def self.default_recipients(subject)
+    return subject.notifiable_member_ids if subject.respond_to?(:notifiable_member_ids)
+
+    []
+  end
+
+  # Projet parent pour le filtrage cross-projets d'Activity (#110).
+  def self.resolve_projectable(subject)
+    if subject.respond_to?(:notification_project)
+      subject.notification_project
+    elsif subject.is_a?(Comment) && subject.commentable.respond_to?(:notification_project)
+      subject.commentable.notification_project
+    end
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -16,3 +16,8 @@ production:
   trainer_document_request:
     class: TrainerDocumentRequestJob
     schedule: every day at 9am
+  # Échéances proches (#104) : notifie la veille (J-1) les abonnés des tâches
+  # datées ayant un assigné. Idempotent (rejeu sans doublon).
+  task_due_soon_notifications:
+    class: TaskDueSoonNotificationJob
+    schedule: every day at 7am

--- a/db/migrate/20260611200000_create_activity_events_and_notifications.rb
+++ b/db/migrate/20260611200000_create_activity_events_and_notifications.rb
@@ -1,0 +1,42 @@
+# Cœur de la couche async calme (#104, epic #101, amendement 11/06) :
+#
+#   ActivityEvent  — 1 ligne par action (flux ambiant, source de vérité).
+#                    Consommé par Activity (#110) ; AUCUN destinataire ici.
+#   Notification   — dérivée d'un ActivityEvent, 1 ligne par destinataire
+#                    abonné/mentionné (#103). Consommée par le Hey! (#105).
+#
+# Le service écrit TOUJOURS l'événement d'abord, puis fan-out les
+# notifications — jamais l'inverse (décision d'architecture du 11/06).
+class CreateActivityEventsAndNotifications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :activity_events do |t|
+      t.bigint :actor_id # nullable : certains événements n'ont pas d'acteur (cf. #110)
+      t.string :action, null: false
+      t.string :subject_type, null: false
+      t.bigint :subject_id, null: false
+      t.string :projectable_type
+      t.bigint :projectable_id
+      t.timestamps
+
+      t.index [:projectable_type, :projectable_id, :created_at], name: "index_activity_events_on_projectable_and_created_at"
+      t.index [:subject_type, :subject_id], name: "index_activity_events_on_subject"
+      t.index [:created_at], name: "index_activity_events_on_created_at"
+    end
+
+    create_table :notifications do |t|
+      t.references :recipient, null: false, foreign_key: { to_table: :members }
+      t.references :activity_event, null: false, foreign_key: true
+      t.string :notifiable_type, null: false
+      t.bigint :notifiable_id, null: false
+      t.string :kind, null: false
+      t.bigint :actor_id
+      t.datetime :read_at
+      t.timestamps
+
+      t.index [:recipient_id, :read_at], name: "index_notifications_on_recipient_and_read_at"
+      # Idempotence du fan-out : un même événement ne notifie jamais deux fois
+      # le même destinataire.
+      t.index [:recipient_id, :activity_event_id], unique: true, name: "index_notifications_on_recipient_and_event"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_11_190000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -366,6 +366,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_190000) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "activity_events", force: :cascade do |t|
+    t.string "action", null: false
+    t.bigint "actor_id"
+    t.datetime "created_at", null: false
+    t.bigint "projectable_id"
+    t.string "projectable_type"
+    t.bigint "subject_id", null: false
+    t.string "subject_type", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_activity_events_on_created_at"
+    t.index ["projectable_type", "projectable_id", "created_at"], name: "index_activity_events_on_projectable_and_created_at"
+    t.index ["subject_type", "subject_id"], name: "index_activity_events_on_subject"
   end
 
   create_table "album_media_items", force: :cascade do |t|
@@ -1504,6 +1518,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_190000) do
     t.index ["notion_id"], name: "index_notes_on_notion_id", unique: true
     t.index ["pole_project_id"], name: "index_notes_on_pole_project_id"
     t.index ["title"], name: "idx_notes_title_trgm", opclass: :gin_trgm_ops, using: :gin
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "activity_event_id", null: false
+    t.bigint "actor_id"
+    t.datetime "created_at", null: false
+    t.string "kind", null: false
+    t.bigint "notifiable_id", null: false
+    t.string "notifiable_type", null: false
+    t.datetime "read_at"
+    t.bigint "recipient_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["activity_event_id"], name: "index_notifications_on_activity_event_id"
+    t.index ["recipient_id", "activity_event_id"], name: "index_notifications_on_recipient_and_event", unique: true
+    t.index ["recipient_id", "read_at"], name: "index_notifications_on_recipient_and_read_at"
+    t.index ["recipient_id"], name: "index_notifications_on_recipient_id"
   end
 
   create_table "notion_assets", force: :cascade do |t|
@@ -2794,6 +2824,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_190000) do
   add_foreign_key "mentions", "comments"
   add_foreign_key "mentions", "members"
   add_foreign_key "notes", "pole_projects"
+  add_foreign_key "notifications", "activity_events"
+  add_foreign_key "notifications", "members", column: "recipient_id"
   add_foreign_key "notion_assets", "notion_records"
   add_foreign_key "nursery_documentation_entries", "nursery_nurseries", column: "nursery_id"
   add_foreign_key "nursery_order_lines", "nursery_nurseries", column: "nursery_id"

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -1,0 +1,207 @@
+require 'test_helper'
+
+# Notifications + activity_events (#104, epic #101, amendement 11/06).
+# Couvre : séquence événement-puis-fan-out, les 5 déclencheurs (assignation,
+# ping, commentaire, mention, échéance J-1), jamais-l'acteur, respect des
+# abonnements/mute de #103, idempotence (rejeu sans doublon), conception
+# ouverte (nouveau type d'événement sans refonte).
+#
+# Pas d'endpoint dans cette issue (pure persistance interne) : le seul appel
+# HTTP réutilise l'endpoint commentaires de #102, sans impact OpenAPI.
+class NotificationsTest < ActionDispatch::IntegrationTest
+  setup do
+    @actor = create_member(first_name: 'Ada')
+    @assignee = create_member(first_name: 'Boris')
+    @watcher = create_member(first_name: 'Carl')
+    Thread.current[:test_member] = @actor
+
+    @project = PoleProject.create!(name: 'Communication', pole: 'academy')
+    [@actor, @assignee, @watcher].each do |m|
+      ProjectMembership.create!(projectable: @project, member: m, role: 'member')
+    end
+    @list = TaskList.create!(name: 'À faire', taskable: @project)
+    @task = @list.tasks.create!(name: 'Préparer la réunion', status: 'pending')
+  end
+
+  teardown { Thread.current[:test_member] = nil }
+
+  # ── Déclencheur : assignation ────────────────────────────────────────────
+
+  test 'assignment writes the event first then notifies the assignee, never the actor' do
+    assert_difference -> { ActivityEvent.count } => 1 do
+      @task.update!(assignee: @assignee, assigned_by: @actor)
+    end
+
+    event = ActivityEvent.last
+    assert_equal 'task_assigned', event.action
+    assert_equal @task, event.subject
+    assert_equal @project, event.projectable
+    assert_equal @actor, event.actor
+
+    notifications = event.notifications
+    assert_equal [@assignee.id], notifications.map(&:recipient_id)
+    assert_equal 'assignment', notifications.first.kind
+    assert_equal @task, notifications.first.notifiable
+  end
+
+  test 'self-assignment writes the event but notifies nobody' do
+    assert_difference -> { ActivityEvent.count } => 1, -> { Notification.count } => 0 do
+      @task.update!(assignee: @actor, assigned_by: @actor)
+    end
+  end
+
+  # ── Déclencheur : ping (coucou) ──────────────────────────────────────────
+
+  test 'pinging a task notifies its subscribers with kind ping' do
+    @task.update!(assignee: @assignee, assigned_by: @actor)
+
+    assert_difference -> { Notification.where(kind: 'ping').count } => 1 do
+      @task.update!(pinged_at: Time.current, pinged_by: @actor)
+    end
+    assert_equal @assignee.id, Notification.where(kind: 'ping').last.recipient_id
+  end
+
+  test 'removing a ping does not notify' do
+    @task.update!(assignee: @assignee, assigned_by: @actor, pinged_at: Time.current, pinged_by: @actor)
+
+    assert_no_difference -> { ActivityEvent.where(action: 'task_pinged').count } do
+      @task.update!(pinged_at: nil, pinged_by: nil)
+    end
+  end
+
+  # ── Déclencheurs : commentaire + mention (via l'endpoint HTTP de #102) ──
+
+  test 'a comment notifies subscribers (kind comment) and mentioned members (kind mention), never the author' do
+    @task.auto_subscribe!(@watcher)
+    body = %(<p>On avance <span data-type="mention" data-id="#{@assignee.id}">@Boris</span> ?</p>)
+
+    assert_difference -> { ActivityEvent.where(action: 'comment_created').count } => 1 do
+      post "/api/v1/tasks/#{@task.id}/comments", params: { body: body }, as: :json
+    end
+    assert_response :created
+
+    event = ActivityEvent.where(action: 'comment_created').last
+    kinds = event.notifications.group_by(&:kind).transform_values { |n| n.map(&:recipient_id) }
+    assert_equal [@assignee.id], kinds['mention'], 'le mentionné reçoit une notification mention'
+    assert_equal [@watcher.id], kinds['comment'], "l'abonné reçoit une notification comment"
+    refute_includes event.notifications.map(&:recipient_id), @actor.id, "l'auteur n'est jamais notifié"
+  end
+
+  test 'a mentioned member gets exactly one notification, not mention plus comment' do
+    body = %(<p><span data-type="mention" data-id="#{@assignee.id}">@Boris</span></p>)
+    @task.comments.create!(author: @actor, body: body)
+
+    assert_equal 1, Notification.where(recipient_id: @assignee.id).count
+    assert_equal 'mention', Notification.where(recipient_id: @assignee.id).first.kind
+  end
+
+  # ── Respect des abonnements / mute (#103) ────────────────────────────────
+
+  test 'project mute silences auto subscribers but explicit follow passes through' do
+    @task.auto_subscribe!(@assignee)
+    @task.subscribe!(@watcher)
+    @project.mute!(@assignee)
+    @project.mute!(@watcher)
+
+    @task.comments.create!(author: @actor, body: '<p>silence ?</p>')
+
+    recipient_ids = ActivityEvent.where(action: 'comment_created').last.notifications.map(&:recipient_id)
+    refute_includes recipient_ids, @assignee.id, 'abonné auto muté = silencé'
+    assert_includes recipient_ids, @watcher.id, 'suivi explicite traverse le mute'
+  end
+
+  test 'an unsubscribed member is never notified' do
+    @task.auto_subscribe!(@watcher)
+    @task.unsubscribe!(@watcher)
+
+    @task.comments.create!(author: @actor, body: '<p>rien pour Carl</p>')
+
+    refute_includes Notification.all.map(&:recipient_id), @watcher.id
+  end
+
+  # ── Déclencheur : échéance proche (J-1, job recurring) ──────────────────
+
+  test 'due-soon job notifies subscribers of tasks due tomorrow with an assignee' do
+    due = @list.tasks.create!(name: 'Pour demain', status: 'pending', due_date: Date.tomorrow)
+    due.update!(assignee: @assignee, assigned_by: @actor)
+    @list.tasks.create!(name: 'Sans assigné', status: 'pending', due_date: Date.tomorrow)
+    @list.tasks.create!(name: 'Pas demain', status: 'pending', due_date: 3.days.from_now.to_date, assignee_id: nil)
+    done = @list.tasks.create!(name: 'Finie', status: 'pending', due_date: Date.tomorrow)
+    done.update!(assignee: @assignee, assigned_by: @actor)
+    done.update!(status: 'completed')
+
+    assert_difference -> { ActivityEvent.where(action: 'task_due_soon').count } => 1 do
+      TaskDueSoonNotificationJob.perform_now
+    end
+
+    event = ActivityEvent.where(action: 'task_due_soon').last
+    assert_equal due, event.subject
+    assert_nil event.actor
+    assert_equal 'due_soon', event.notifications.first.kind
+    assert_equal [@assignee.id], event.notifications.map(&:recipient_id)
+  end
+
+  test 'replaying the due-soon job the same day creates no duplicates' do
+    due = @list.tasks.create!(name: 'Pour demain', status: 'pending', due_date: Date.tomorrow)
+    due.update!(assignee: @assignee, assigned_by: @actor)
+
+    TaskDueSoonNotificationJob.perform_now
+    assert_no_difference [-> { ActivityEvent.count }, -> { Notification.count }] do
+      TaskDueSoonNotificationJob.perform_now
+    end
+  end
+
+  # ── Idempotence du fan-out ───────────────────────────────────────────────
+
+  test 'fanning out twice for the same event never duplicates a notification' do
+    @task.auto_subscribe!(@watcher)
+    event = NotificationService.record!(action: 'task_assigned', subject: @task, actor: @actor)
+
+    assert_no_difference -> { Notification.count } do
+      Notification.create_or_find_by!(recipient_id: @watcher.id, activity_event_id: event.id) do |n|
+        n.notifiable = @task
+        n.kind = 'assignment'
+      end
+    end
+  end
+
+  # ── Conçu ouvert : nouveau notifiable_type sans refonte ─────────────────
+
+  test 'recording an arbitrary new event type works without any plumbing change' do
+    deliberation = Strategy::Deliberation.create!(title: 'Statuts', status: 'open', created_by_id: @watcher.id)
+    deliberation.subscribe!(@assignee)
+
+    event = NotificationService.record!(
+      action: 'checkin_answered', subject: deliberation, actor: @watcher,
+      kind_for: ->(_) { 'checkin' }
+    )
+
+    assert_equal 'checkin_answered', event.action
+    recipient_ids = event.notifications.map(&:recipient_id)
+    assert_includes recipient_ids, @assignee.id
+    refute_includes recipient_ids, @watcher.id, "l'acteur (pourtant abonné auto) n'est pas notifié"
+    assert_equal 'checkin', event.notifications.first.kind
+  end
+
+  # ── Nettoyage en cascade ─────────────────────────────────────────────────
+
+  test 'destroying a commented object cascades its events and notifications' do
+    @task.auto_subscribe!(@watcher)
+    @task.comments.create!(author: @actor, body: '<p>bientôt supprimé</p>')
+
+    assert_difference -> { ActivityEvent.count } => -1, -> { Notification.count } => -1 do
+      @task.comments.last.destroy!
+    end
+  end
+
+  private
+
+  def create_member(first_name:)
+    Member.create!(
+      first_name: first_name, last_name: 'H',
+      email: "#{first_name.downcase}-#{SecureRandom.hex(4)}@test.be",
+      status: 'active', joined_at: Time.current, member_kind: 'human',
+      membership_type: 'effective'
+    )
+  end
+end


### PR DESCRIPTION
Closes #104 — Epic #101, Phase 1, brique 3/6. S'appuie sur #102 (mentions) et #103 (abonnements, mergés).

## Ce que fait cette PR

Le **cœur du Hey!** : la table d'événements + le service unique de génération de notifications, conformément au body de l'issue (décisions actées du 10/06 **et amendement d'architecture `activity_events` du 11/06**).

### Architecture (amendement appliqué)
- **`ActivityEvent`** — 1 ligne par action, sans destinataire : `actor` (nullable, cf. décision #110), `action`, `subject` polymorphe, `projectable` polymorphe (filtrage cross-projets), horodatage indexé. C'est la **source de vérité** que le flux Activity (#110) lira directement.
- **`Notification`** — toujours **dérivée** d'un `ActivityEvent` : `recipient`, `notifiable` polymorphe (lien cliquable), `kind`, `actor_id`, `read_at` (+ `mark_read!` prêt pour #105). Index (recipient, read_at) pour la boîte, index **unique (recipient, activity_event)** pour l'idempotence du fan-out.
- **`NotificationService.record!`** — séquence invariante : événement d'abord, fan-out ensuite. **Conçu ouvert** (critère de l'issue) : un nouveau type d'événement (ex. réponse de check-in en Phase 3) = un appel, zéro refonte — testé tel quel avec un type arbitraire. `kind_for` permet des kinds par destinataire : un seul événement `comment_created` notifie en `mention` les mentionnés et en `comment` les autres abonnés (pas de double notification).

### Les 5 déclencheurs câblés
| Déclencheur | Hook | Acteur |
|---|---|---|
| Assignation | `Task` after_save (après l'abonnement auto #103) | `assigned_by` |
| Coucou (ping) | `Task` after_save sur `pinged_at` (le retrait ne notifie pas) | `pinged_by` |
| Commentaire | `Comment` after_save post-création (après extraction des mentions) | auteur |
| @mention | même événement, kind `mention` | auteur |
| Échéance **J-1** | `TaskDueSoonNotificationJob` — recurring **7h** (`config/recurring.yml`, qui existait déjà contrairement à la note d'audit de l'issue) ; exige un `assignee` (décision actée) | aucun |

### Doctrine calme respectée et testée
- **Jamais l'acteur** (même s'il est abonné) ; auto-assignation = événement écrit, zéro notification.
- **Abonnements/mute #103** : résolution via `notifiable_member_ids` — abonné auto muté silencé, **suivi explicite traverse le mute**, désabonné jamais notifié.
- **Idempotence** : rejeu du job d'échéance le même jour = 0 doublon (garde sur l'événement du jour + index unique du fan-out) — test dédié comme exigé.
- Suppression en cascade : détruire un commentaire/une tâche emporte ses événements et notifications (pas de lignes orphelines).

## Vérification
- `test/integration/notifications_test.rb` : **13 tests, 52 assertions** — dont un end-to-end HTTP via l'endpoint commentaires de #102.
- Suite complète : **837 runs, 3 194 assertions, 0 failure, 0 error** (les hooks tirent sur toutes les créations de tâches/commentaires de la suite : aucun effet de bord).
- OpenAPI : **zéro dérive** — aucun endpoint dans cette issue (pure persistance interne, décision actée) ; seul le bruit data-dépendant connu (academy/design) est apparu et a été écarté.

## Hors-scope (conforme à l'issue)
UI Hey! (#105), flux Activity (#110), distribution email/Slack (#106). Les `strategy_deliberation_comments` existants ne sont pas bridgés ici (le bridge viendra avec #105/#110).
