### PR TITLE
Digest email calme + heures calmes, Slack en débordement opt-in (#106)

### DIFF
--- a/app/jobs/notification_digest_job.rb
+++ b/app/jobs/notification_digest_job.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Digest email calme (#106) — tourne chaque matin (~8h Europe/Brussels) via
+# solid_queue (config/recurring.yml). Remplace l'email-par-événement par UN
+# seul récapitulatif quotidien des notifications internes non-lues.
+#
+# Garanties :
+#   • Heures calmes — aucun email poussé hors de la plage choisie par le membre
+#     (la boîte interne, elle, continue de se remplir).
+#   • Pas de doublon — un seul digest par membre et par jour (idempotent au
+#     rejeu via `digest_last_sent_on`).
+#   • Opt-out — un membre peut couper le digest (`email_digest_opt_in = false`).
+class NotificationDigestJob < ApplicationJob
+  queue_as :default
+
+  def perform(now: Time.current)
+    today = now.in_time_zone(Member::QUIET_HOURS_TIME_ZONE).to_date
+
+    Member.where(status: "active", email_digest_opt_in: true)
+          .where.not(email: [nil, ""])
+          .find_each do |member|
+      deliver_for(member, now, today)
+    end
+  end
+
+  private
+
+  def deliver_for(member, now, today)
+    return if member.digest_last_sent_on == today          # déjà envoyé aujourd'hui
+    return unless member.email_push_allowed_at?(now)        # heures calmes
+
+    notifications = member.received_notifications.unread.recent_first.includes(:actor, :notifiable).to_a
+    return if notifications.empty?                          # rien à dire → pas d'email
+
+    NotificationDigestMailer.daily_digest(member, notifications).deliver_now
+    member.update_column(:digest_last_sent_on, today)
+  end
+end

--- a/app/mailers/notification_digest_mailer.rb
+++ b/app/mailers/notification_digest_mailer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Digest email calme (#106) — un seul récapitulatif par membre et par jour des
+# notifications internes non-lues (boîte Hey! #105), au lieu d'un email par
+# événement. Envoyé via SES (`:ses_v2` en prod) par NotificationDigestJob, qui
+# garantit l'unicité quotidienne et le respect des heures calmes.
+class NotificationDigestMailer < ApplicationMailer
+  def daily_digest(member, notifications)
+    @member = member
+    @notifications = notifications
+    @count = notifications.size
+    # Lien « voir dans Terranova » : la boîte Hey! est une cloche présente dans
+    # le shell sur toutes les pages, donc on pointe vers la racine de l'app.
+    @app_url = root_url
+
+    mail(
+      to: @member.email,
+      subject: "Votre récap Terranova — #{@count} #{@count > 1 ? 'nouveautés' : 'nouveauté'}"
+    )
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -66,4 +66,27 @@ class Member < ApplicationRecord
   def guild_ids_list
     project_memberships.where(projectable_type: "Guild").pluck(:projectable_id)
   end
+
+  # ── Distribution calme (#106) ─────────────────────────────────────────────
+  # Notifications internes (boîte Hey! #105) reçues par ce membre.
+  has_many :received_notifications, class_name: "Notification", foreign_key: :recipient_id, dependent: :destroy
+
+  # Heures calmes — fuseau Europe/Brussels FIXE pour tous (décision 18/06) ;
+  # seule la plage [end, start) est ajustable. Push email autorisé uniquement
+  # dans cette plage (par défaut 8h–19h, soit silence 19h–8h). En dehors, la
+  # boîte interne se remplit toujours, mais aucun email n'est poussé.
+  QUIET_HOURS_TIME_ZONE = "Europe/Brussels"
+
+  def email_push_allowed_at?(time = Time.current)
+    hour = time.in_time_zone(QUIET_HOURS_TIME_ZONE).hour
+    start_hour = quiet_hours_start_hour
+    end_hour = quiet_hours_end_hour
+    if end_hour <= start_hour
+      # Plage de push non-traversante (cas par défaut 8h..19h).
+      hour >= end_hour && hour < start_hour
+    else
+      # Plage de push traversant minuit (silence en milieu de journée).
+      hour >= end_hour || hour < start_hour
+    end
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -25,4 +25,39 @@ class Notification < ApplicationRecord
   def mark_read!
     update!(read_at: Time.current) unless read?
   end
+
+  # Libellé lisible pour le digest email (#106). Conçu ouvert : un kind inconnu
+  # retombe sur une forme humanisée plutôt que de planter.
+  KIND_VERBS = {
+    "assignment" => "vous a assigné",
+    "task_assigned" => "vous a assigné",
+    "mention" => "vous a mentionné·e sur",
+    "comment" => "a commenté",
+    "comment_created" => "a commenté",
+    "ping" => "vous a fait coucou sur",
+    "due_soon" => "— échéance proche :",
+    "task_due_soon" => "— échéance proche :"
+  }.freeze
+
+  def summary
+    verb = KIND_VERBS[kind] || kind.to_s.tr("_", " ")
+    [actor_name, verb, target_label].compact.join(" ").strip
+  end
+
+  def actor_name
+    return "Quelqu'un" if actor.nil?
+
+    "#{actor.first_name} #{actor.last_name}".strip
+  end
+
+  def target_label
+    target = notifiable
+    return nil if target.nil?
+
+    if target.respond_to?(:title) && target.title.present?
+      "« #{target.title.to_s.truncate(60)} »"
+    elsif target.respond_to?(:name) && target.name.present?
+      "« #{target.name.to_s.truncate(60)} »"
+    end
+  end
 end

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -5,8 +5,17 @@ require "uri"
 require "json"
 
 class SlackNotifier
+  # Slack n'est plus le canal par défaut (#106, « remplacer Slack ») : la source
+  # de vérité est la boîte interne Hey! + le digest email. Slack reste un canal
+  # de DÉBORDEMENT optionnel, OFF par défaut — on l'active explicitement en
+  # posant SLACK_OVERFLOW_ENABLED=true.
+  def self.overflow_enabled?
+    ENV["SLACK_OVERFLOW_ENABLED"] == "true"
+  end
+
   def self.post(text:, url: nil)
     return if Rails.env.test?
+    return unless overflow_enabled?
 
     webhook_url = url || ENV["SLACK_WEBHOOK_URL"]
     return if webhook_url.blank?

--- a/app/views/notification_digest_mailer/daily_digest.html.erb
+++ b/app/views/notification_digest_mailer/daily_digest.html.erb
@@ -1,0 +1,44 @@
+<h2 style="margin: 0 0 16px; font-size: 20px; color: #234766;">
+  Votre récap du jour
+</h2>
+
+<p>Bonjour <%= @member.first_name %>,</p>
+
+<p>
+  Voici ce qui s'est passé sur Terranova depuis votre dernier passage —
+  <strong><%= @count %></strong>
+  <%= @count > 1 ? "notifications non-lues" : "notification non-lue" %>
+  dans votre boîte Hey!.
+</p>
+
+<ul style="padding-left: 18px; margin: 20px 0;">
+  <% @notifications.each do |notification| %>
+    <li style="margin-bottom: 10px;">
+      <%= notification.summary %>
+      <span style="color: #999999; font-size: 12px;">
+        (<%= l(notification.created_at, format: :short) rescue notification.created_at.strftime("%d/%m %H:%M") %>)
+      </span>
+    </li>
+  <% end %>
+</ul>
+
+<p style="text-align: center; margin: 32px 0;">
+  <a href="<%= @app_url %>"
+     style="display: inline-block; padding: 12px 32px; background-color: #5B5781;
+            color: #ffffff; text-decoration: none; border-radius: 8px;
+            font-weight: 600; font-size: 14px;">
+    Voir dans Terranova
+  </a>
+</p>
+
+<p style="font-size: 13px; color: #666666; border-top: 1px solid #eeeeee; padding-top: 16px;">
+  <strong>Pour rester calme&nbsp;:</strong>
+  travail → on écrit sur l'objet concerné dans Terranova ·
+  urgent → téléphone ·
+  social → hors outil.
+</p>
+
+<p style="font-size: 12px; color: #999999;">
+  Vous recevez un seul récap par jour. Réglez vos heures calmes ou désactivez
+  ce digest depuis votre profil.
+</p>

--- a/app/views/notification_digest_mailer/daily_digest.text.erb
+++ b/app/views/notification_digest_mailer/daily_digest.text.erb
@@ -1,0 +1,19 @@
+Votre récap du jour
+===================
+
+Bonjour <%= @member.first_name %>,
+
+Voici ce qui s'est passé sur Terranova depuis votre dernier passage —
+<%= @count %> <%= @count > 1 ? "notifications non-lues" : "notification non-lue" %> dans votre boîte Hey!.
+
+<% @notifications.each do |notification| -%>
+- <%= notification.summary %> (<%= notification.created_at.strftime("%d/%m %H:%M") %>)
+<% end -%>
+
+Voir dans Terranova : <%= @app_url %>
+
+Pour rester calme : travail -> on écrit sur l'objet concerné dans Terranova ;
+urgent -> téléphone ; social -> hors outil.
+
+Vous recevez un seul récap par jour. Réglez vos heures calmes ou désactivez
+ce digest depuis votre profil.

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -21,3 +21,9 @@ production:
   task_due_soon_notifications:
     class: TaskDueSoonNotificationJob
     schedule: every day at 7am
+  # Digest email calme (#106) : un seul récap quotidien par membre des
+  # notifications non-lues, ~8h Europe/Brussels (fuseau explicite — l'app tourne
+  # en UTC). Le job re-filtre par heures calmes du membre et garantit l'unicité.
+  notification_digest:
+    class: NotificationDigestJob
+    schedule: "0 8 * * * Europe/Brussels"

--- a/db/migrate/20260619020434_add_notification_preferences_to_members.rb
+++ b/db/migrate/20260619020434_add_notification_preferences_to_members.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Préférences de distribution calme (#106) : digest email + heures calmes.
+# Fuseau des heures calmes = Europe/Brussels FIXE pour tous (décision 18/06) ;
+# seule la plage est ajustable par membre. Push email autorisé dans
+# [quiet_hours_end_hour, quiet_hours_start_hour) ; défaut 8h–19h (silence 19h–8h).
+class AddNotificationPreferencesToMembers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :members, :email_digest_opt_in, :boolean, default: true, null: false
+    add_column :members, :quiet_hours_start_hour, :integer, default: 19, null: false
+    add_column :members, :quiet_hours_end_hour, :integer, default: 8, null: false
+    # Idempotence du digest : un seul envoi par jour et par membre (un rejeu du
+    # job le même jour ne renvoie pas un second email).
+    add_column :members, :digest_last_sent_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_11_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_19_020434) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -1473,7 +1473,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_200000) do
     t.string "avatar", default: "", null: false
     t.string "calendar_token"
     t.datetime "created_at", null: false
+    t.date "digest_last_sent_on"
     t.string "email", null: false
+    t.boolean "email_digest_opt_in", default: true, null: false
     t.string "first_name", null: false
     t.boolean "is_admin", default: false, null: false
     t.date "joined_at", null: false
@@ -1484,6 +1486,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_200000) do
     t.text "notes"
     t.text "notes_html"
     t.string "password_digest"
+    t.integer "quiet_hours_end_hour", default: 8, null: false
+    t.integer "quiet_hours_start_hour", default: 19, null: false
     t.string "slack_user_id"
     t.string "status", default: "active", null: false
     t.datetime "updated_at", null: false

--- a/test/jobs/notification_digest_job_test.rb
+++ b/test/jobs/notification_digest_job_test.rb
@@ -1,0 +1,97 @@
+require 'test_helper'
+
+# Digest email calme (#106). Couvre : agrégation (UN seul email récapitulatif,
+# pas un par événement), respect des heures calmes (aucun envoi hors plage),
+# idempotence (pas de doublon sur la journée), opt-out, et le cas « rien à dire ».
+class NotificationDigestJobTest < ActiveJob::TestCase
+  include ActionMailer::TestHelper
+
+  setup do
+    @member = create_member(first_name: 'Ada')
+    @project = PoleProject.create!(name: 'Communication', pole: 'academy')
+    @list = TaskList.create!(name: 'À faire', taskable: @project)
+    # Heures Bruxelles en juin = CEST (UTC+2). Plage de push par défaut 8h–19h
+    # Bruxelles = 6h–17h UTC.
+    @push_time = Time.utc(2026, 6, 19, 9, 0)   # 11h Bruxelles → push autorisé
+    @quiet_time = Time.utc(2026, 6, 19, 4, 0)  # 6h Bruxelles → heures calmes
+  end
+
+  test 'envoie UN seul digest agrégeant toutes les notifications non-lues' do
+    create_unread_notification(@member, name: 'Tâche 1')
+    create_unread_notification(@member, name: 'Tâche 2')
+
+    assert_emails 1 do
+      NotificationDigestJob.perform_now(now: @push_time)
+    end
+
+    mail = ActionMailer::Base.deliveries.last
+    assert_equal [@member.email], mail.to
+    # Corps décodé (le brut est encodé quoted-printable, accents compris).
+    text_body = mail.text_part.body.decoded
+    assert_match 'Tâche 1', text_body
+    assert_match 'Tâche 2', text_body
+    assert_equal Date.new(2026, 6, 19), @member.reload.digest_last_sent_on
+  end
+
+  test 'ne pousse aucun email pendant les heures calmes' do
+    create_unread_notification(@member, name: 'Tâche 1')
+
+    assert_no_emails do
+      NotificationDigestJob.perform_now(now: @quiet_time)
+    end
+    assert_nil @member.reload.digest_last_sent_on
+  end
+
+  test 'idempotent — un second passage le même jour ne renvoie rien' do
+    create_unread_notification(@member, name: 'Tâche 1')
+
+    assert_emails 1 do
+      NotificationDigestJob.perform_now(now: @push_time)
+    end
+    assert_no_emails do
+      NotificationDigestJob.perform_now(now: @push_time)
+    end
+  end
+
+  test "respecte l'opt-out du digest" do
+    @member.update!(email_digest_opt_in: false)
+    create_unread_notification(@member, name: 'Tâche 1')
+
+    assert_no_emails do
+      NotificationDigestJob.perform_now(now: @push_time)
+    end
+  end
+
+  test "n'envoie rien quand il n'y a aucune notification non-lue" do
+    assert_no_emails do
+      NotificationDigestJob.perform_now(now: @push_time)
+    end
+    assert_nil @member.reload.digest_last_sent_on
+  end
+
+  test 'ignore les notifications déjà lues' do
+    note = create_unread_notification(@member, name: 'Tâche 1')
+    note.mark_read!
+
+    assert_no_emails do
+      NotificationDigestJob.perform_now(now: @push_time)
+    end
+  end
+
+  private
+
+  def create_member(first_name:)
+    Member.create!(
+      first_name: first_name, last_name: 'H',
+      email: "#{first_name.downcase}-#{SecureRandom.hex(4)}@test.be",
+      status: 'active', joined_at: Time.current, member_kind: 'human',
+      membership_type: 'effective'
+    )
+  end
+
+  def create_unread_notification(member, name:)
+    task = @list.tasks.create!(name: name, status: 'pending')
+    event = ActivityEvent.create!(action: 'task_assigned', subject: task, actor: nil, projectable: @project)
+    Notification.create!(recipient: member, activity_event: event, notifiable: task, kind: 'assignment')
+  end
+end

--- a/test/mailers/previews/notification_digest_mailer_preview.rb
+++ b/test/mailers/previews/notification_digest_mailer_preview.rb
@@ -1,0 +1,17 @@
+# Aperçu du digest calme (#106) : http://localhost:PORT/rails/mailers/notification_digest_mailer/daily_digest
+# Objets construits en mémoire (aucune écriture en base) pour rendre l'email.
+class NotificationDigestMailerPreview < ActionMailer::Preview
+  def daily_digest
+    member = Member.new(first_name: "Ada", email: "ada@semisto.org")
+    task = Task.new(name: "Préparer la réunion d'équipe")
+    other = Member.new(first_name: "Boris", last_name: "H")
+
+    notifications = [
+      Notification.new(kind: "assignment", notifiable: task, created_at: Time.current),
+      Notification.new(kind: "comment", notifiable: task, actor: other, created_at: 3.hours.ago),
+      Notification.new(kind: "mention", notifiable: task, actor: other, created_at: 6.hours.ago)
+    ]
+
+    NotificationDigestMailer.daily_digest(member, notifications)
+  end
+end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -15,4 +15,21 @@ class MemberTest < ActiveSupport::TestCase
     m = Member.new(membership_type: "non_member")
     assert_not m.can_access_strategy?
   end
+
+  # Heures calmes (#106) — fenêtre de push par défaut 8h–19h Europe/Brussels.
+  test "email_push_allowed_at? respects the default 8h-19h Brussels window" do
+    m = Member.new(quiet_hours_start_hour: 19, quiet_hours_end_hour: 8)
+    # Juin = CEST (UTC+2).
+    assert m.email_push_allowed_at?(Time.utc(2026, 6, 19, 9, 0))      # 11h Bruxelles
+    assert_not m.email_push_allowed_at?(Time.utc(2026, 6, 19, 4, 0))  # 6h Bruxelles
+    assert_not m.email_push_allowed_at?(Time.utc(2026, 6, 19, 20, 0)) # 22h Bruxelles
+  end
+
+  test "email_push_allowed_at? supports a push window crossing midnight" do
+    # Plage de push 22h–6h (silence en pleine journée) : end(22) > start(6).
+    m = Member.new(quiet_hours_start_hour: 6, quiet_hours_end_hour: 22)
+    assert m.email_push_allowed_at?(Time.utc(2026, 6, 19, 21, 0))     # 23h Bruxelles
+    assert m.email_push_allowed_at?(Time.utc(2026, 6, 19, 2, 0))      # 4h Bruxelles
+    assert_not m.email_push_allowed_at?(Time.utc(2026, 6, 19, 10, 0)) # 12h Bruxelles
+  end
 end


### PR DESCRIPTION
Refs #106 — cœur technique de la distribution calme (digest email + heures calmes + Slack en débordement opt-in).

## Ce que fait la PR

**Bascule de Slack vers la boîte interne comme canal par défaut**, avec un digest email quotidien et des heures calmes — conforme aux décisions du 18/06 (1 digest/jour ~8h, silence 19h–8h **Europe/Brussels fixe pour tous**, plage ajustable par membre, Slack opt-in off par défaut).

- **`NotificationDigestJob`** (recurring, `config/recurring.yml`, cron `0 8 * * * Europe/Brussels`) : pour chaque membre actif ayant opté pour le digest, **un seul email** récapitulant ses notifications **non-lues** (boîte Hey! #105), au lieu d'un email par événement. Envoyé via SES (`ApplicationMailer` → `:ses_v2` en prod).
- **Heures calmes par membre** : nouvelles colonnes `quiet_hours_start_hour` / `quiet_hours_end_hour` (défaut 19/8) + `email_digest_opt_in` (défaut true) + `digest_last_sent_on` (idempotence). `Member#email_push_allowed_at?` calcule la fenêtre de push en **Europe/Brussels** (gère aussi une fenêtre traversant minuit). Hors plage → aucun email poussé (la boîte interne, elle, continue de se remplir).
- **Pas de doublon** : un seul digest par membre et par jour (`digest_last_sent_on`), idempotent au rejeu du job.
- **Slack n'est plus le canal par défaut** : `SlackNotifier.post` est gaté **off par défaut** (`SLACK_OVERFLOW_ENABLED=true` pour l'activer). Les pings existants (dépôt doc formateur, paiement Stripe) deviennent donc du **débordement opt-in**.
- **Lien « Voir dans Terranova »** dans l'email → racine de l'app (la cloche Hey! `HeyBell` est dans le shell sur toutes les pages). Le **pied du digest publie la règle d'usage à 3 branches** (travail → écrit dans Terranova · urgent → téléphone · social → hors outil).

Aucun endpoint API touché → **pas de régénération OpenAPI** nécessaire. Aucun fichier frontend touché → eslint/tsc non impactés.

## Tests

`bin/rails test` : **869 runs, 0 failure, 0 error** (suite complète verte).

Nouveaux tests :
- `test/jobs/notification_digest_job_test.rb` — agrégation (1 seul email, pas un par événement), respect des heures calmes (aucun envoi hors plage), idempotence (pas de doublon le même jour), opt-out, cas « aucune non-lue », ignore les déjà-lues.
- `test/models/member_test.rb` — fenêtre de push 8h–19h Bruxelles + cas traversant minuit.

## NON testé / reste à faire (honnêteté)

Deux critères de **renforcement organisationnels** de l'issue ne sont **pas** livrables en autonomie et restent à trancher par Michael :
- [ ] **Page Knowledge dédiée** « règle d'usage à 3 branches » : la règle est **publiée dans le pied du digest** (et liée à l'app), mais pas encore comme page Knowledge autonome.
- [ ] **Date de sunset Slack + métrique de transition hebdo** : décision de date + accès analytics Slack requis (hors code).

Également laissé en suivi : **UI profil** pour éditer ses heures calmes / opt-out (les colonnes + le comportement existent et sont testés ; il manque l'écran de réglage côté React).

Le digest n'a pas été envoyé pour de vrai via SES (pas de credentials en test) — vérifié via l'aperçu mailer + les tests d'agrégation/livraison.

## Notes

- Fuseau : l'app tourne en UTC ; le cron porte un fuseau explicite `Europe/Brussels` et la garde heures-calmes recalcule en Bruxelles, donc le comportement reste correct été comme hiver.
- `SlackNotifier` était déjà un ping latéral (pas un dispatcher central) — le « dé-câblage du canal par défaut » se réduit donc à le rendre opt-in.

## 📸 Aperçu

![Digest email calme (#106)](https://github.com/semisto-org/terranova/raw/agent-screenshots/screenshots/20260619-041306-digest-email-calme-106.png)
