### PR TITLE
Dépenses : refresh ciblé de ligne + indicateur de document (#131)

### DIFF
--- a/app/frontend/lab-management/components/ExpenseList.tsx
+++ b/app/frontend/lab-management/components/ExpenseList.tsx
@@ -622,6 +622,24 @@ export function ExpenseList({
                               <AlertTriangle className="w-3.5 h-3.5 text-red-500" />
                             </span>
                           )}
+                          {/* Indicateur de justificatif (#131) : icône en évidence et
+                              cliquable si un document est attaché, atténuée sinon. */}
+                          {e.documentUrl ? (
+                            <a
+                              href={e.documentUrl}
+                              target="_blank"
+                              rel="noopener"
+                              onClick={(ev) => ev.stopPropagation()}
+                              title={e.documentFilename || 'Voir le document'}
+                              className="shrink-0 text-[#5B5781] hover:text-[#46426a] transition-colors"
+                            >
+                              <FileText className="w-3.5 h-3.5" />
+                            </a>
+                          ) : (
+                            <span title="Aucun document" className="shrink-0 text-stone-300" aria-hidden>
+                              <FileText className="w-3.5 h-3.5" />
+                            </span>
+                          )}
                           <span className="font-medium text-stone-900 truncate max-w-[260px]">
                             {e.supplier || <span className="text-stone-400 italic">Sans fournisseur</span>}
                           </span>

--- a/app/frontend/pages/Admin/Settings.jsx
+++ b/app/frontend/pages/Admin/Settings.jsx
@@ -421,20 +421,40 @@ export default function AdminSettings({ currentMemberId: initialMemberId }) {
             : {}),
       }
       // The projectable quick-edit modal does its own PATCH then calls back here
-      // with { projectableType, projectableId, projectName } — we just need to refetch
-      // to surface the new project name in the list.
+      // with { projectableType, projectableId, projectName } — its primary path
+      // already does a surgical onRowReplace; this callback is only the fallback.
       const projectableChanged =
         Object.prototype.hasOwnProperty.call(changes, 'projectableType') ||
         Object.prototype.hasOwnProperty.call(changes, 'projectableId')
       if (!Object.keys(payload).length && !projectableChanged) return
       await runAndRefresh(async () => {
         if (Object.keys(payload).length) {
-          await apiRequest(`/api/v1/lab/expenses/${expenseId}`, {
+          // Le PATCH renvoie déjà la dépense sérialisée complète : on remplace
+          // uniquement la ligne concernée à partir de cette réponse, sans
+          // refetch global ni flash de chargement du tableau (#131).
+          const updated = await apiRequest(`/api/v1/lab/expenses/${expenseId}`, {
             method: 'PATCH',
             body: JSON.stringify(payload),
           })
+          if (updated?.id) {
+            setExpenses((prev) => prev.map((e) => (e.id === updated.id ? updated : e)))
+          }
+        } else if (projectableChanged) {
+          // Fallback du quick-edit projet (réponse PATCH indisponible côté modal) :
+          // mise à jour locale de la seule ligne, sans refetch global.
+          setExpenses((prev) =>
+            prev.map((e) =>
+              e.id === expenseId
+                ? {
+                    ...e,
+                    projectableType: changes.projectableType ?? null,
+                    projectableId: changes.projectableId ?? null,
+                    projectName: changes.projectName ?? null,
+                  }
+                : e
+            )
+          )
         }
-        await loadExpenses()
       })
     },
     onBulkExpenseUpdate: async (ids, changes) => {


### PR DESCRIPTION
Closes #131

Deux améliorations indépendantes sur le tableau **Administration → Dépenses**, frontend pur (aucun changement backend, contrat API inchangé).

## Ce que fait la PR

### Amélioration 1 — Refresh ciblé de la ligne (plus de refetch global)
`onInlineExpenseUpdate` (`app/frontend/pages/Admin/Settings.jsx`) **capture désormais la réponse du `PATCH /api/v1/lab/expenses/:id`** (le backend renvoie déjà la dépense sérialisée complète) et remplace **uniquement la ligne concernée** via `setExpenses((prev) => prev.map(...))`, au lieu d'appeler `loadExpenses()`.
- Plus de `GET /api/v1/lab/expenses` après le `PATCH` ; plus de flash (`expensesLoading` ne repasse pas à `true`).
- Couvre **tous** les champs inline (statut, catégorie, pôles, remboursé, date de remboursement) car ils passent tous par ce handler unique.
- `loadOverview()` est **conservé** (via `runAndRefresh`) : les KPIs du panneau restent corrects, sans toucher l'état du tableau.
- En cas d'échec du PATCH, la ligne n'est pas modifiée (le `setExpenses` n'a lieu qu'après un `await` réussi) et l'erreur remonte comme avant.
- Le quick-edit « projet » continue d'utiliser son chemin `onRowReplace` (surgical) ; le fallback (réponse PATCH indisponible côté modal) met à jour la ligne **localement**, sans réintroduire de refetch global.

### Amélioration 2 — Indicateur de document par ligne
Icône `FileText` (lucide-react, déjà importée) inline dans la cellule « Fournisseur · Libellé » :
- **Document présent** (`documentUrl` non nul) : icône en accent (`#5B5781`), **cliquable** → ouvre `documentUrl` dans un nouvel onglet (`rel="noopener"`), tooltip = `documentFilename`.
- **Document absent** : icône atténuée (`text-stone-300`), non cliquable, tooltip « Aucun document ».
- Placée **inline** (pas de colonne ajoutée) → aucun impact sur l'alignement des colonnes ni le responsive. `documentUrl`/`documentFilename` sont déjà exposés par l'API et présents dans le type `ExpenseItem`.

## Tests

Changement **frontend uniquement** → pas de nouveau test Minitest requis, contrat API inchangé (spec OpenAPI inchangée). Gates CI reproduites en local :
- `yarn tsc --noEmit` ✅
- `yarn eslint app/frontend/ --ext .ts,.tsx,.js,.jsx` ✅ — **0 erreur** (196 warnings, tous pré-existants dans `plant-database/`, aucun dans les fichiers modifiés).
- `yarn build` (vite) ✅ — compile bout-à-bout.

## NON testé (honnêteté)

- **Pas de capture d'écran** : la page Administration → Dépenses est derrière l'authentification de session et ce repo n'a **pas** de harnais Capybara / system-test, donc une capture en run nocturne **headless** n'est pas possible (Interceptor est exclu du run headless). Le changement visuel (icône document) est décrit ci-dessus ; à vérifier visuellement en relecture sur l'écran réel.
- La vérification réseau « un seul PATCH, aucun GET ensuite » décrite dans l'issue se fait via Interceptor (manuel) — non exécutable headless. La logique du fix garantit ce comportement (suppression de l'appel `loadExpenses()` dans le chemin inline).

## Notes

- Hors-scope respecté : `onBulkExpenseUpdate` (multi-lignes) inchangé ; modal d'édition, recettes et suppression non touchés.
