### PR TITLE
fix(expenses): dépenses multi-projets attribuées à chaque projet alloué

### DIFF
--- a/app/controllers/api/v1/academy_controller.rb
+++ b/app/controllers/api/v1/academy_controller.rb
@@ -549,15 +549,24 @@ module Api
             vr > 0 ? (r.amount_paid.to_f / (1 + vr / 100.0)).round(2) : r.amount_paid.to_f
           end
         end
-        expenses = trainings.sum { |item| item.expenses.sum(&:amount_excl_vat).to_f }
+        expenses = trainings.sum do |training|
+          training.attributed_expenses.sum { |expense| expense.attributed_amount_excl_vat_for(training).to_f }
+        end
         total_participants = trainings.sum { |item| item.registrations.size }
 
         by_status = Academy::Training::STATUSES.index_with do |status|
           trainings.count { |t| t.status == status }
         end
 
-        training_ids = trainings.map(&:id)
-        expenses_by_category = Expense.where(projectable_type: 'Academy::Training', projectable_id: training_ids).where.not(category: nil).group(:category).sum(:amount_excl_vat).transform_values(&:to_f)
+        expenses_by_category = Hash.new(0.to_d)
+        trainings.each do |training|
+          training.attributed_expenses.each do |expense|
+            next if expense.category.nil?
+
+            expenses_by_category[expense.category] += expense.attributed_amount_excl_vat_for(training)
+          end
+        end
+        expenses_by_category.transform_values!(&:to_f)
 
         fill_rates = trainings.filter_map do |t|
           cap = t.total_capacity
@@ -635,7 +644,9 @@ module Api
           .order(registered_at: :desc)
         attendances = Academy::TrainingAttendance.where(registration_id: Academy::TrainingRegistration.select(:id)).order(updated_at: :desc)
         documents = Academy::TrainingDocument.order(uploaded_at: :desc)
-        expenses = Expense.where(projectable_type: 'Academy::Training').order(invoice_date: :desc)
+        training_expenses = trainings.flat_map do |training|
+          training.attributed_expenses.map { |expense| [expense, training] }
+        end.sort_by { |expense, _training| expense.invoice_date || Date.new(0) }.reverse
         idea_notes = Academy::IdeaNote.order(created_at: :desc)
         members = Member.order(:first_name, :last_name)
         team = Contact.joins(:contact_tags)
@@ -656,7 +667,7 @@ module Api
           trainingRegistrations: registrations.map { |item| serialize_registration(item) },
           trainingAttendances: attendances.map { |item| serialize_attendance(item) },
           trainingDocuments: documents.map { |item| serialize_document(item) },
-          trainingExpenses: expenses.map { |item| serialize_expense(item) },
+          trainingExpenses: training_expenses.map { |item, training| serialize_expense(item, projectable: training) },
           ideaNotes: idea_notes.map { |item| serialize_idea_note(item) },
           members: members.map { |item| serialize_member(item) },
           academyContacts: team.map { |item| serialize_academy_contact(item) },
@@ -995,12 +1006,14 @@ module Api
         }
       end
 
-      def serialize_expense(item)
+      def serialize_expense(item, projectable: nil)
         doc_url = item.document.attached? ? Rails.application.routes.url_helpers.rails_blob_url(item.document, only_path: true) : nil
-        {
-          id: item.id.to_s,
-          projectableType: item.projectable_type,
-          projectableId: item.projectable_id&.to_s,
+        amount_excl_vat = projectable ? item.attributed_amount_excl_vat_for(projectable) : item.amount_excl_vat.to_d
+        total_incl_vat = projectable ? item.attributed_amount_incl_vat_for(projectable) : item.total_incl_vat.to_d
+        payload = {
+          id: projectable && item.multi_project? ? "#{item.id}-#{projectable.id}" : item.id.to_s,
+          projectableType: projectable ? projectable.class.name : item.projectable_type,
+          projectableId: projectable ? projectable.id.to_s : item.projectable_id&.to_s,
           supplier: item.supplier_display_name,
           supplierContactId: item.supplier_contact_id&.to_s,
           status: item.status,
@@ -1010,12 +1023,12 @@ module Api
           billingZone: item.billing_zone,
           paymentDate: item.payment_date&.iso8601,
           paymentType: item.payment_type,
-          amountExclVat: item.amount_excl_vat.to_f,
+          amountExclVat: amount_excl_vat.to_f,
           vatRate: item.vat_rate,
           vat6: item.vat_6.to_f,
           vat12: item.vat_12.to_f,
           vat21: item.vat_21.to_f,
-          totalInclVat: item.total_incl_vat.to_f,
+          totalInclVat: total_incl_vat.to_f,
           euVatRate: item.eu_vat_rate,
           euVatAmount: item.eu_vat_amount.to_f,
           paidBy: item.paid_by,
@@ -1031,6 +1044,15 @@ module Api
           createdAt: item.created_at.iso8601,
           updatedAt: item.updated_at.iso8601
         }
+        if projectable
+          payload.merge!(
+            attributedAmountInclVat: total_incl_vat.to_f,
+            attributedAmountExclVat: amount_excl_vat.to_f,
+            isAllocation: item.multi_project?,
+            fullTotalInclVat: item.total_incl_vat.to_f
+          )
+        end
+        payload
       end
 
       def serialize_idea_note(item)

--- a/app/controllers/api/v1/design_studio_controller.rb
+++ b/app/controllers/api/v1/design_studio_controller.rb
@@ -398,7 +398,7 @@ module Api
         project = find_project
         item = project.expenses.create!(expense_params)
         item.document.attach(params[:document]) if params[:document].present?
-        project.update!(expenses_actual: project.expenses.sum(:total_incl_vat))
+        update_expenses_actual!(project)
         render json: serialize_expense(item.reload), status: :created
       end
 
@@ -407,7 +407,7 @@ module Api
         item.update!(expense_params)
         item.document.attach(params[:document]) if params[:document].present?
         project = item.projectable
-        project&.update!(expenses_actual: project.expenses.sum(:total_incl_vat)) if project.is_a?(Design::Project)
+        update_expenses_actual!(project) if project.is_a?(Design::Project)
         render json: serialize_expense(item.reload)
       end
 
@@ -415,7 +415,7 @@ module Api
         item = Expense.find(params.require(:expense_id))
         project = item.projectable
         item.soft_delete!
-        project&.update!(expenses_actual: project.expenses.sum(:total_incl_vat)) if project.is_a?(Design::Project)
+        update_expenses_actual!(project) if project.is_a?(Design::Project)
         head :no_content
       end
 
@@ -1187,7 +1187,7 @@ module Api
           project: serialize_project(project),
           teamMembers: project.team_members.order(:assigned_at).map { |item| serialize_team_member(item) },
           timesheets: project.timesheets.order(date: :desc).map { |item| serialize_timesheet(item) },
-          expenses: project.expenses.order(invoice_date: :desc).map { |item| serialize_expense(item) },
+          expenses: project.attributed_expenses.sort_by { |item| item.invoice_date || Date.new(0) }.reverse.map { |item| serialize_expense(item, projectable: project) },
           siteAnalysis: serialize_site_analysis(project.site_analysis),
           plantPalette: serialize_project_palette(palette),
           plantingPlan: serialize_planting_plan(planting_plan),
@@ -1493,11 +1493,17 @@ module Api
       end
 
       def serialize_client_expenses(project)
-        billable = project.expenses.where(billable_to_client: true)
+        billable = project.attributed_expenses.select(&:billable_to_client)
         grouped = billable.group_by(&:category).map do |category, items|
-          { category: category.presence || 'Autres', subtotal: items.sum { |e| e.total_incl_vat.to_f }.round(2), count: items.size }
+          { category: category.presence || 'Autres', subtotal: items.sum { |e| e.attributed_amount_incl_vat_for(project).to_f }.round(2), count: items.size }
         end.sort_by { |g| -g[:subtotal] }
-        { categories: grouped, total: billable.sum(:total_incl_vat).to_f.round(2) }
+        { categories: grouped, total: billable.sum { |e| e.attributed_amount_incl_vat_for(project).to_f }.round(2) }
+      end
+
+      def update_expenses_actual!(project)
+        project.update!(
+          expenses_actual: project.attributed_expenses.sum { |expense| expense.attributed_amount_incl_vat_for(project) }
+        )
       end
 
       def recalculate_quote_totals!(quote)
@@ -1668,13 +1674,15 @@ module Api
         }
       end
 
-      def serialize_expense(item)
+      def serialize_expense(item, projectable: nil)
         doc_url = item.document.attached? ? Rails.application.routes.url_helpers.rails_blob_url(item.document, only_path: true) : nil
-        {
-          id: item.id.to_s,
-          projectableType: item.projectable_type,
-          projectableId: item.projectable_id&.to_s,
-          projectName: item.projectable&.project_name,
+        amount_excl_vat = projectable ? item.attributed_amount_excl_vat_for(projectable) : item.amount_excl_vat.to_d
+        total_incl_vat = projectable ? item.attributed_amount_incl_vat_for(projectable) : item.total_incl_vat.to_d
+        payload = {
+          id: projectable && item.multi_project? ? "#{item.id}-#{projectable.id}" : item.id.to_s,
+          projectableType: projectable ? projectable.class.name : item.projectable_type,
+          projectableId: projectable ? projectable.id.to_s : item.projectable_id&.to_s,
+          projectName: projectable ? projectable.project_name : item.projectable&.project_name,
           supplier: item.supplier_display_name,
           supplierContactId: item.supplier_contact_id&.to_s,
           status: item.status,
@@ -1684,12 +1692,12 @@ module Api
           billingZone: item.billing_zone,
           paymentDate: item.payment_date&.iso8601,
           paymentType: item.payment_type,
-          amountExclVat: item.amount_excl_vat.to_f,
+          amountExclVat: amount_excl_vat.to_f,
           vatRate: item.vat_rate,
           vat6: item.vat_6.to_f,
           vat12: item.vat_12.to_f,
           vat21: item.vat_21.to_f,
-          totalInclVat: item.total_incl_vat.to_f,
+          totalInclVat: total_incl_vat.to_f,
           euVatRate: item.eu_vat_rate,
           euVatAmount: item.eu_vat_amount.to_f,
           paidBy: item.paid_by,
@@ -1705,6 +1713,15 @@ module Api
           createdAt: item.created_at.iso8601,
           updatedAt: item.updated_at.iso8601
         }
+        if projectable
+          payload.merge!(
+            attributedAmountInclVat: total_incl_vat.to_f,
+            attributedAmountExclVat: amount_excl_vat.to_f,
+            isAllocation: item.multi_project?,
+            fullTotalInclVat: item.total_incl_vat.to_f
+          )
+        end
+        payload
       end
 
       def serialize_site_analysis(item)

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -227,8 +227,8 @@ module Api
 
       # GET /api/v1/projects/:type/:id/expenses
       def list_expenses
-        expenses = @projectable.expenses.where(deleted_at: nil).order(invoice_date: :desc)
-        render json: { items: expenses.map { |e| serialize_expense(e) } }
+        expenses = @projectable.attributed_expenses.sort_by { |expense| expense.invoice_date || Date.new(0) }.reverse
+        render json: { items: expenses.map { |e| serialize_expense(e, projectable: @projectable) } }
       end
 
       # POST /api/v1/projects/:type/:id/expenses
@@ -597,7 +597,7 @@ module Api
           taskLists: task_lists,
           notes: project.has_attribute?(:notes) ? project.read_attribute(:notes).to_s : "",
           documents: documents_for(project).map { |d| serialize_document(d) },
-          expensesCount: project.expenses.where(deleted_at: nil).count,
+          expensesCount: project.attributed_expenses.count,
           revenuesCount: project.revenues.where(deleted_at: nil).count,
           timesheetsCount: project.timesheets.count,
           eventsCount: project.events.where(deleted_at: nil).count,
@@ -674,10 +674,12 @@ module Api
         end
       end
 
-      def serialize_expense(item)
+      def serialize_expense(item, projectable: nil)
         doc_url = item.document.attached? ? Rails.application.routes.url_helpers.rails_blob_url(item.document, only_path: true) : nil
-        {
-          id: item.id.to_s,
+        amount_excl_vat = projectable ? item.attributed_amount_excl_vat_for(projectable) : item.amount_excl_vat.to_d
+        total_incl_vat = projectable ? item.attributed_amount_incl_vat_for(projectable) : item.total_incl_vat.to_d
+        payload = {
+          id: projectable && item.multi_project? ? "#{item.id}-#{projectable.id}" : item.id.to_s,
           name: item.name,
           supplier: item.supplier_display_name,
           supplierContactId: item.supplier_contact_id&.to_s,
@@ -687,11 +689,11 @@ module Api
           category: item.category,
           billingZone: item.billing_zone,
           vatRate: item.vat_rate,
-          amountExclVat: item.amount_excl_vat.to_f,
+          amountExclVat: amount_excl_vat.to_f,
           vat6: item.vat_6.to_f,
           vat12: item.vat_12.to_f,
           vat21: item.vat_21.to_f,
-          totalInclVat: item.total_incl_vat.to_f,
+          totalInclVat: total_incl_vat.to_f,
           poles: item.poles,
           paymentType: item.payment_type,
           paymentDate: item.payment_date&.iso8601,
@@ -699,11 +701,20 @@ module Api
           rebillingStatus: item.rebilling_status,
           notes: item.notes,
           documentUrl: doc_url,
-          projectableType: item.projectable_type,
-          projectableId: item.projectable_id&.to_s,
-          projectName: item.projectable&.project_name,
+          projectableType: projectable ? projectable.class.name : item.projectable_type,
+          projectableId: projectable ? projectable.id.to_s : item.projectable_id&.to_s,
+          projectName: projectable ? projectable.project_name : item.projectable&.project_name,
           createdAt: item.created_at.iso8601
         }
+        if projectable
+          payload.merge!(
+            attributedAmountInclVat: total_incl_vat.to_f,
+            attributedAmountExclVat: amount_excl_vat.to_f,
+            isAllocation: item.multi_project?,
+            fullTotalInclVat: item.total_incl_vat.to_f
+          )
+        end
+        payload
       end
 
       def serialize_revenue(r)

--- a/app/models/concerns/projectable.rb
+++ b/app/models/concerns/projectable.rb
@@ -23,6 +23,23 @@ module Projectable
     respond_to?(:title) ? title : name
   end
 
+  def attributed_expenses
+    primary_expenses = expenses
+      .where(deleted_at: nil)
+      .where.not(id: ExpenseProjectAllocation.select(:expense_id))
+      .select(:id)
+
+    allocated_expenses = ExpenseProjectAllocation
+      .where(projectable_type: self.class.name, projectable_id: id)
+      .select(:expense_id)
+
+    Expense
+      .where(id: primary_expenses)
+      .or(Expense.where(deleted_at: nil, id: allocated_expenses))
+      .distinct
+      .includes(:project_allocations)
+  end
+
   # ── Mute projet (#103) ────────────────────────────────────────────────────
   # Un membre peut couper TOUTES les notifications d'un projet (état `muted`
   # sur le Projectable lui-même). Le suivi explicite d'un objet du projet

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -70,6 +70,23 @@ class Expense < ApplicationRecord
     project_allocations.any?
   end
 
+  def attributed_amount_incl_vat_for(projectable)
+    return total_incl_vat.to_d unless multi_project?
+
+    project_allocations
+      .select { |allocation| allocation.projectable_type == projectable.class.name && allocation.projectable_id.to_s == projectable.id.to_s }
+      .sum(0.to_d) { |allocation| allocation.amount.to_d }
+  end
+
+  def attributed_amount_excl_vat_for(projectable)
+    return amount_excl_vat.to_d unless multi_project?
+
+    total = total_incl_vat.to_d
+    return 0.to_d if total.zero?
+
+    (attributed_amount_incl_vat_for(projectable) / total * amount_excl_vat.to_d).round(2)
+  end
+
   after_save :record_cash_movement!
   after_destroy :unrecord_cash_movement!
 

--- a/test/integration/expense_allocations_test.rb
+++ b/test/integration/expense_allocations_test.rb
@@ -1,0 +1,111 @@
+require "test_helper"
+
+class ExpenseAllocationsTest < ActionDispatch::IntegrationTest
+  setup do
+    [
+      ExpenseProjectAllocation,
+      AlbumMediaItem,
+      Album,
+      Academy::TrainingAttendance,
+      Academy::RegistrationPack,
+      Expense,
+      Academy::TrainingDocument,
+      Academy::RegistrationItem,
+      Academy::TrainingRegistration,
+      Academy::TrainingPackItem,
+      Academy::TrainingPack,
+      Academy::TrainingSession,
+      Academy::ParticipantCategory,
+      Academy::Training,
+      Academy::TrainingLocation,
+      Academy::TrainingType,
+      Academy::IdeaNote,
+      ContactTag,
+      Contact
+    ].each(&:delete_all)
+
+    @training_type = Academy::TrainingType.create!(name: "Permaculture", description: "Base")
+    @training_a = Academy::Training.create!(training_type: @training_type, title: "Training A", status: "idea")
+    @training_b = Academy::Training.create!(training_type: @training_type, title: "Training B", status: "idea")
+
+    @split_expense = @training_a.expenses.create!(
+      supplier: "Shared supplier",
+      status: "processing",
+      invoice_date: Date.new(2026, 1, 10),
+      expense_type: "services_and_goods",
+      category: "Shared",
+      name: "Shared room",
+      total_incl_vat: 300,
+      amount_excl_vat: 240,
+      vat_21: 60
+    )
+    ExpenseProjectAllocation.create!(expense: @split_expense, projectable: @training_a, amount: 100)
+    ExpenseProjectAllocation.create!(expense: @split_expense, projectable: @training_b, amount: 150)
+
+    @single_project_expense = @training_a.expenses.create!(
+      supplier: "Local supplier",
+      status: "processing",
+      invoice_date: Date.new(2026, 1, 11),
+      expense_type: "services_and_goods",
+      category: "Local",
+      name: "Local room",
+      total_incl_vat: 50,
+      amount_excl_vat: 40,
+      vat_21: 10
+    )
+  end
+
+  test "academy payload attributes split expenses to every allocated training" do
+    get "/api/v1/academy", as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    rows = body["trainingExpenses"]
+    split_a = rows.find { |row| row["id"] == "#{@split_expense.id}-#{@training_a.id}" }
+    split_b = rows.find { |row| row["id"] == "#{@split_expense.id}-#{@training_b.id}" }
+    single = rows.find { |row| row["id"] == @single_project_expense.id.to_s }
+
+    assert split_a, "expected split expense row for first training"
+    assert split_b, "expected split expense row for second training"
+    assert single, "expected non-split expense row"
+    assert_equal 2, rows.count { |row| row["id"].start_with?("#{@split_expense.id}-") }
+    assert_equal 1, rows.count { |row| row["id"] == @single_project_expense.id.to_s }
+
+    assert_equal "Academy::Training", split_a["projectableType"]
+    assert_equal @training_a.id.to_s, split_a["projectableId"]
+    assert_equal true, split_a["isAllocation"]
+    assert_in_delta 100.0, split_a["totalInclVat"], 0.01
+    assert_in_delta 80.0, split_a["amountExclVat"], 0.01
+    assert_in_delta 100.0, split_a["attributedAmountInclVat"], 0.01
+    assert_in_delta 80.0, split_a["attributedAmountExclVat"], 0.01
+    assert_in_delta 300.0, split_a["fullTotalInclVat"], 0.01
+
+    assert_equal "Academy::Training", split_b["projectableType"]
+    assert_equal @training_b.id.to_s, split_b["projectableId"]
+    assert_equal true, split_b["isAllocation"]
+    assert_in_delta 150.0, split_b["totalInclVat"], 0.01
+    assert_in_delta 120.0, split_b["amountExclVat"], 0.01
+    assert_in_delta 150.0, split_b["attributedAmountInclVat"], 0.01
+    assert_in_delta 120.0, split_b["attributedAmountExclVat"], 0.01
+    assert_in_delta 300.0, split_b["fullTotalInclVat"], 0.01
+
+    assert_equal "Academy::Training", single["projectableType"]
+    assert_equal @training_a.id.to_s, single["projectableId"]
+    assert_equal false, single["isAllocation"]
+    assert_in_delta 50.0, single["totalInclVat"], 0.01
+    assert_in_delta 40.0, single["amountExclVat"], 0.01
+    assert_in_delta 50.0, single["attributedAmountInclVat"], 0.01
+    assert_in_delta 40.0, single["attributedAmountExclVat"], 0.01
+    assert_in_delta 250.0, rows.select { |row| row["isAllocation"] }.sum { |row| row["totalInclVat"].to_f }, 0.01
+  end
+
+  test "academy reporting sums attributed HTVA by category without primary project double count" do
+    get "/api/v1/academy/reporting", as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_in_delta 240.0, body["totalExpenses"], 0.01
+    assert_in_delta 200.0, body["expensesByCategory"]["Shared"], 0.01
+    assert_in_delta 40.0, body["expensesByCategory"]["Local"], 0.01
+  end
+end


### PR DESCRIPTION
## Problème

Une dépense (`Expense`) a un projet principal (`belongs_to :projectable`) **et** peut être répartie sur plusieurs projets via `expense_project_allocations`. Or toutes les vues/reportings de dépenses par projet lisaient uniquement `@projectable.expenses` (projet principal) et **ignoraient les allocations**. Résultat : une dépense répartie n'apparaissait que chez son projet principal — les projets secondaires ne la voyaient jamais (ni liste, ni reporting). Repéré sur « Parcelle Fruits-Dupuis (Anderlecht) » (dépense Métadesign 23/10/2023 répartie sur 3 projets).

## Correction

- **`Projectable#attributed_expenses`** : dépenses du projet = (principales **non réparties**) ∪ (celles **allouées** au projet). Une dépense répartie compte uniquement via ses allocations (jamais en double via le principal).
- **`Expense#attributed_amount_{incl,excl}_vat_for(projectable)`** : montant attribué — allocation en TTC, HTVA **au prorata** (`alloc_TTC / total_incl_vat × amount_excl_vat`, garde `total==0`).
- Câblage **academy** (liste + reporting + `expensesByCategory`), **projects** (`list_expenses`, `expensesCount`), **design** (liste, `expenses_actual`, client expenses).
- `serialize_expense(item, projectable:)` expose les montants attribués + champs additifs `attributedAmount{Incl,Excl}Vat`, `isAllocation`, `fullTotalInclVat`. Le reste non alloué n'est imputé à aucun projet.

## Tests

`test/integration/expense_allocations_test.rb` (2 tests, 34 assertions) : dépense répartie 300 TTC → 100 (A) + 150 (B), prorata HTVA 80/120, reste 50 non imputé ; reporting `totalExpenses=240` sans double comptage. **Suite complète : 599 runs, 0 failure.**

## ⚠️ À faire avant merge

- **Régénérer la spec OpenAPI** côté runner CI (nouveaux champs `attributedAmount*`/`isAllocation`/`fullTotalInclVat`). Le regen local diverge (gotcha connu `terranova-openapi-ci-gate`) — à committer depuis le runner figé.

## Vérif post-déploiement

Confirmer sur prod que la dépense Métadesign 23/10/2023 apparaît bien dans les comptes de #48 avec son montant alloué.
