### PR TITLE
fix(bank): import all Triodos CODA transactions (54% were silently dropped)

### DIFF
--- a/app/services/bank_sync/coda_importer.rb
+++ b/app/services/bank_sync/coda_importer.rb
@@ -59,9 +59,15 @@ module BankSync
     end
 
     def build_transaction_id(movement)
-      # Combine bank reference with value date for uniqueness
+      # Belgian banks (e.g. Triodos) often leave bank_reference blank, so it
+      # cannot anchor uniqueness on its own. The CODA sequence number is the
+      # bank-assigned, per-statement stable identifier — combined with the value
+      # date and signed amount it uniquely identifies a movement and stays
+      # idempotent when the same file is re-imported.
       date_str = (movement.value_date || movement.booking_date)&.iso8601 || "nodate"
-      "coda_#{@bank_connection.id}_#{movement.bank_reference}_#{date_str}"
+      signed_amount = movement.sign == :credit ? movement.amount : -movement.amount
+      ref = movement.bank_reference.presence || movement.sequence
+      "coda_#{@bank_connection.id}_#{ref}_#{date_str}_#{signed_amount.to_s('F')}"
     end
   end
 end

--- a/app/services/bank_sync/coda_parser.rb
+++ b/app/services/bank_sync/coda_parser.rb
@@ -46,18 +46,23 @@ module BankSync
           detail_type = line[1]
           case detail_type
           when "1"
+            # A new movement starts: flush the previous one. Lines 22/23 are
+            # optional, so a movement may consist of a 21 line only — it must
+            # still be captured rather than overwritten by the next 21.
+            result.movements << current_movement if current_movement
             current_movement = parse_movement_line1(line)
           when "2"
             parse_movement_line2(line, current_movement) if current_movement
           when "3"
             parse_movement_line3(line, current_movement) if current_movement
-            result.movements << current_movement if current_movement
-            current_movement = nil
           end
         when "3"
           # Information records — skip (supplementary details)
           next
         when "8"
+          # End of a statement: flush the last movement before reading the balance.
+          result.movements << current_movement if current_movement
+          current_movement = nil
           parse_new_balance(line, result)
         when "9"
           # Trailer — skip

--- a/app/services/bank_sync/coda_parser.rb
+++ b/app/services/bank_sync/coda_parser.rb
@@ -88,9 +88,10 @@ module BankSync
 
     def parse_old_balance(line, result)
       result.account_number = extract_account_number(line[5, 37])
-      result.old_balance_sign = line[41] == "0" ? :credit : :debit
-      result.old_balance = parse_amount(line[42, 15])
-      result.old_balance_date = parse_date(line[57, 6])
+      sign, amount, date = parse_balance_fields(line)
+      result.old_balance_sign = sign
+      result.old_balance = amount
+      result.old_balance_date = date
     end
 
     def parse_movement_line1(line)
@@ -139,9 +140,23 @@ module BankSync
     end
 
     def parse_new_balance(line, result)
-      result.new_balance_sign = line[41] == "0" ? :credit : :debit
-      result.new_balance = parse_amount(line[42, 15])
-      result.new_balance_date = parse_date(line[57, 6])
+      sign, amount, date = parse_balance_fields(line)
+      result.new_balance_sign = sign
+      result.new_balance = amount
+      result.new_balance_date = date
+    end
+
+    # The balance records (type 1 = old, type 8 = new) hold a 1-char sign,
+    # a 15-digit amount and a 6-digit date. Triodos shifts the old-balance
+    # record one position to the right versus the spec/new-balance record, so
+    # anchor on the sign column ("0" credit / "1" debit) to locate the fields
+    # rather than hardcoding an offset.
+    def parse_balance_fields(line)
+      offset = %w[0 1].include?(line[41]) ? 41 : 42
+      sign = line[offset] == "0" ? :credit : :debit
+      amount = parse_amount(line[offset + 1, 15])
+      date = parse_date(line[offset + 16, 6])
+      [sign, amount, date]
     end
 
     def parse_amount(raw)

--- a/script/migrate_coda_transaction_ids.rb
+++ b/script/migrate_coda_transaction_ids.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+# One-off production migration: re-key existing CODA-imported transactions to the
+# new deduplication-id scheme introduced in fix/coda-blank-bank-reference, WITHOUT
+# losing reconciliations, then create the movements that the old buggy importer
+# silently dropped.
+#
+# WHY
+# ---
+# The old importer keyed transactions on `coda_<conn>_<bank_reference>_<date>`.
+# Triodos leaves bank_reference blank, so every same-day movement collapsed onto
+# one id and ~54% of movements were skipped as "duplicates". The new importer
+# keys on `coda_<conn>_<sequence>_<date>_<signed_amount>`. The new ids do not
+# match the old ones, so a plain re-import would DUPLICATE the transactions that
+# already exist (and their reconciliations would stay attached to the old rows).
+#
+# The CODA sequence number is not stored on BankTransaction, so the old id cannot
+# be recomputed from the row alone. This script therefore re-parses the original
+# CODA file(s) — which DO carry the sequence — and matches each existing
+# transaction to its movement by content (date + signed amount + communication),
+# then rewrites its provider_transaction_id to the new scheme via update_column
+# (no callbacks, reconciliations preserved). Movements with no existing match are
+# created by a normal re-import afterwards.
+#
+# USAGE
+# -----
+#   # dry-run (default): reports what would change, writes nothing
+#   bin/rails runner script/migrate_coda_transaction_ids.rb <connection_id> <coda_file> [<coda_file>...]
+#
+#   # apply
+#   APPLY=1 bin/rails runner script/migrate_coda_transaction_ids.rb <connection_id> <coda_file> [...]
+#
+#   # apply even if some existing rows could not be matched (NOT recommended —
+#   # unmatched rows that stay on the old id will be duplicated by the re-import)
+#   APPLY=1 FORCE=1 bin/rails runner script/migrate_coda_transaction_ids.rb <connection_id> <coda_file> [...]
+#
+# The script is idempotent: a second run finds every row already on the new id,
+# remaps nothing, and imports nothing.
+
+apply = ENV["APPLY"] == "1"
+force = ENV["FORCE"] == "1"
+
+connection_id = ARGV[0]
+files = ARGV[1..] || []
+
+abort "usage: migrate_coda_transaction_ids.rb <connection_id> <coda_file> [...]" if connection_id.blank? || files.empty?
+
+connection = BankConnection.find(connection_id)
+importer = BankSync::CodaImporter.new(connection)
+parser = BankSync::CodaParser.new
+
+missing = files.reject { |f| File.exist?(f) }
+abort "fichier(s) introuvable(s): #{missing.join(', ')}" if missing.any?
+
+puts "Connexion ##{connection.id} (#{connection.provider}, #{connection.iban})"
+puts "Mode: #{apply ? 'APPLY (écriture)' : 'DRY-RUN (lecture seule)'}#{force ? ' FORCE' : ''}"
+puts "Fichiers: #{files.join(', ')}"
+puts
+
+# Parse every file into a flat list of movements (each carries its sequence).
+movements = files.flat_map { |f| parser.parse(File.read(f)).movements }
+puts "Mouvements dans le(s) fichier(s): #{movements.size}"
+
+# Pre-compute the canonical new id for each movement using the importer's own
+# private builder — single source of truth, immune to drift.
+movement_new_id = movements.to_h { |m| [m, importer.send(:build_transaction_id, m)] }
+
+signed = ->(m) { m.sign == :credit ? m.amount : -m.amount }
+mov_date = ->(m) { m.value_date || m.booking_date }
+
+# Only touch rows this importer owns.
+existing = connection.bank_transactions.where("provider_transaction_id LIKE ?", "coda_#{connection.id}_%").to_a
+puts "Transactions CODA existantes en base: #{existing.size}"
+puts
+
+claimed = {} # movement => true
+to_remap = [] # [tx, new_id]
+already_ok = 0
+unmatched = []
+
+existing.each do |tx|
+  candidates = movements.select do |m|
+    !claimed[m] && mov_date.call(m) == tx.date && signed.call(m) == tx.amount
+  end
+
+  # Disambiguate by communication when several movements share date + amount.
+  if candidates.size > 1
+    by_comm = candidates.select { |m| m.communication.to_s.strip == tx.remittance_info.to_s.strip }
+    candidates = by_comm if by_comm.any?
+  end
+
+  movement = candidates.first
+  if movement.nil?
+    unmatched << tx
+    next
+  end
+
+  claimed[movement] = true
+  new_id = movement_new_id[movement]
+  if tx.provider_transaction_id == new_id
+    already_ok += 1
+  else
+    to_remap << [tx, new_id]
+  end
+end
+
+puts "À ré-encoder (ID réécrit) : #{to_remap.size}"
+puts "Déjà au bon format        : #{already_ok}"
+puts "Existantes NON matchées   : #{unmatched.size}"
+unmatched.first(10).each do |tx|
+  puts "  ⚠️  ##{tx.id} #{tx.date} #{tx.amount} € #{tx.remittance_info.to_s[0, 40].inspect} (status=#{tx.status})"
+end
+puts "  … (#{unmatched.size - 10} de plus)" if unmatched.size > 10
+
+would_create = movements.size - (to_remap.size + already_ok)
+puts
+puts "Après réimport, mouvements à créer (manquants) : #{would_create}"
+puts "Total attendu en base après migration          : #{existing.size - unmatched.size + would_create + (unmatched.size)}"
+puts "  (dont #{unmatched.size} non matchées laissées en l'état)" if unmatched.any?
+puts
+
+if unmatched.any? && !force
+  puts "⛔ #{unmatched.size} transaction(s) existante(s) n'ont pas pu être matchées à un mouvement du fichier."
+  puts "   Les réimporter créerait des doublons. Vérifie que tu fournis bien le(s) bon(s) fichier(s) CODA"
+  puts "   couvrant toute la période. Pour forcer malgré tout : FORCE=1 (déconseillé)."
+  abort unless apply == false # in dry-run we still want to show the plan, just don't proceed to write
+end
+
+unless apply
+  puts "DRY-RUN — aucune écriture. Relance avec APPLY=1 pour appliquer."
+  return
+end
+
+if unmatched.any? && !force
+  abort "Abandon: transactions non matchées (voir ci-dessus). FORCE=1 pour outrepasser."
+end
+
+ActiveRecord::Base.transaction do
+  to_remap.each { |tx, new_id| tx.update_column(:provider_transaction_id, new_id) }
+  puts "✅ #{to_remap.size} ID réécrits (rapprochements préservés)."
+
+  total_imported = 0
+  total_skipped = 0
+  files.each do |f|
+    res = BankSync::CodaImporter.new(connection).import(File.read(f))
+    total_imported += res[:imported]
+    total_skipped += res[:skipped]
+  end
+  puts "✅ Réimport: #{total_imported} créées, #{total_skipped} ignorées (déjà présentes)."
+end
+
+connection.reload
+puts
+puts "Total transactions CODA en base maintenant: #{connection.bank_transactions.where('provider_transaction_id LIKE ?', "coda_#{connection.id}_%").count}"

--- a/test/services/bank_sync/coda_importer_test.rb
+++ b/test/services/bank_sync/coda_importer_test.rb
@@ -147,4 +147,57 @@ class BankSync::CodaImporterTest < ActiveSupport::TestCase
     assert_equal 1, @connection.bank_transactions.count
     assert_equal 1, other_connection.bank_transactions.count
   end
+
+  # Builds a single type-21 movement line at the exact offsets the parser reads.
+  # Triodos leaves bank_reference (positions 10-30) blank, which used to collapse
+  # every same-day movement onto one provider_transaction_id.
+  def movement21(seq:, sign:, amount_milli:, date:, ref: "")
+    line = " " * 128
+    line[0, 2]   = "21"
+    line[2, 4]   = seq.to_s.rjust(4, "0")
+    line[6, 4]   = "0000"
+    line[10, 21] = ref.ljust(21)
+    line[31]     = sign # "0" credit, "1" debit
+    line[32, 15] = amount_milli.to_s.rjust(15, "0") # divided by 1000 by the parser
+    line[47, 6]  = date # value date ddmmyy
+    line[53, 8]  = "00150000"
+    line[115, 6] = date # booking date
+    line
+  end
+
+  # Two 21-only movements (no 22/23), same date, blank reference, distinct amounts.
+  # Exercises both the parser flush fix (movement without a closing 23 must not be
+  # dropped) and the dedup-key fix (blank bank_reference must not collapse them).
+  def blank_ref_same_date_coda
+    header  = "0000018032600105        00000000   Semisto ASBL              BBRUBEBB   00932942  00000                                         2"
+    old_bal = "10000BE52523080001234 EUR0000000012345670260301          Semisto ASBL              000                                        0"
+    movA    = movement21(seq: 1, sign: "0", amount_milli: 875_000, date: "150326") # +875.00
+    movB    = movement21(seq: 2, sign: "1", amount_milli: 50_000,  date: "150326") # -50.00
+    new_bal = "8000BE52523080001234 EUR0000000013170670260315                                                                                0"
+    trailer = "9               000002000000000000000000000000000000000                                                                    2"
+
+    build_coda(header, old_bal, movA, movB, new_bal, trailer)
+  end
+
+  test "imports all same-day movements when bank_reference is blank (Triodos)" do
+    importer = BankSync::CodaImporter.new(@connection)
+    result = importer.import(blank_ref_same_date_coda)
+
+    assert_equal 2, result[:movements_total], "both 21-only movements must be parsed"
+    assert_equal 2, result[:imported], "blank reference must not deduplicate distinct movements"
+    assert_equal 0, result[:skipped]
+    assert_equal 2, @connection.bank_transactions.count
+
+    amounts = @connection.bank_transactions.order(:amount).pluck(:amount).map(&:to_f)
+    assert_equal [-50.0, 875.0], amounts
+  end
+
+  test "re-importing the same blank-reference file is idempotent" do
+    BankSync::CodaImporter.new(@connection).import(blank_ref_same_date_coda)
+    result = BankSync::CodaImporter.new(@connection).import(blank_ref_same_date_coda)
+
+    assert_equal 0, result[:imported]
+    assert_equal 2, result[:skipped]
+    assert_equal 2, @connection.bank_transactions.count
+  end
 end

--- a/test/services/bank_sync/coda_parser_test.rb
+++ b/test/services/bank_sync/coda_parser_test.rb
@@ -168,4 +168,48 @@ class BankSync::CodaParserTest < ActiveSupport::TestCase
     result = @parser.parse(content)
     assert_equal 1, result.movements.size
   end
+
+  # Triodos writes the old-balance record (type 1) one position to the right of
+  # the new-balance record (type 8): "1000" + account vs "800" + account. The
+  # sign-anchored balance parser must read both correctly.
+  def triodos_old_balance(sign:, amount_milli:, date:)
+    line = " " * 128
+    line[0, 4]  = "1000"
+    line[4, 13] = "2523081435316"
+    line[17, 4] = " EUR"
+    line[42]    = sign # shifted +1 vs the new-balance record
+    line[43, 15] = amount_milli.to_s.rjust(15, "0")
+    line[58, 6] = date
+    line
+  end
+
+  def triodos_new_balance(sign:, amount_milli:, date:)
+    line = " " * 128
+    line[0, 3]  = "800"
+    line[3, 13] = "2523081435316"
+    line[16, 4] = " EUR"
+    line[41]    = sign
+    line[42, 15] = amount_milli.to_s.rjust(15, "0")
+    line[57, 6] = date
+    line
+  end
+
+  test "reads Triodos balances despite the one-position old-balance shift" do
+    content = build_coda(
+      sample_header_line,
+      triodos_old_balance(sign: "0", amount_milli: 5_736_050, date: "190623"),
+      triodos_new_balance(sign: "0", amount_milli: 9_195_750, date: "190626"),
+      sample_trailer_line
+    )
+
+    result = @parser.parse(content)
+
+    assert_equal BigDecimal("5736.05"), result.old_balance
+    assert_equal :credit, result.old_balance_sign
+    assert_equal Date.new(2023, 6, 19), result.old_balance_date
+
+    assert_equal BigDecimal("9195.75"), result.new_balance
+    assert_equal :credit, result.new_balance_sign
+    assert_equal Date.new(2026, 6, 19), result.new_balance_date
+  end
 end


### PR DESCRIPTION
## Problème

Les imports CODA Triodos perdaient **54 % des transactions**. Sur un export réel de **1219 mouvements, seuls 560 arrivaient en base** — exactement le symptôme remonté (« il manque toute une série de transactions vs l'app Triodos »).

**Cause racine :** Triodos ne remplit jamais le champ `bank_reference` du CODA. Or l'`CodaImporter` dédupliquait sur `coda_<conn>_<ref>_<date>` → tous les mouvements d'un même jour partageaient le même identifiant et étaient jetés comme « doublons ».

## Corrections

### 1. Déduplication (impact majeur)
Clé de dédup désormais basée sur le **numéro de séquence** assigné par la banque (fallback quand `bank_reference` est vide) + date + montant signé. Unique dans un fichier, idempotent sur réimport.

### 2. Parser — mouvements sans ligne `23` (latent)
Un mouvement réduit à sa ligne `21` (lignes `22`/`23` optionnelles) était écrasé par le suivant. Le mouvement courant est maintenant sauvegardé dès qu'un nouveau `21` commence (et au solde final).

### 3. Parser — solde initial Triodos (cosmétique)
L'enregistrement `1` (solde initial) de Triodos est décalé d'un caractère vs l'enregistrement `8` (solde final) → solde lu 573,61 € au lieu de 5736,05 €. Parsing désormais ancré sur la colonne de signe. Sans impact sur l'import, mais nécessaire pour la réconciliation comptable.

### 4. Import auto-cicatrisant (migration des données prod, sans accès serveur)
Les transactions déjà en prod ont l'**ancien** ID ; un réimport naïf les **dupliquerait**. Plutôt qu'un script server-side (le fichier CODA n'existe qu'en local), l'importer est rendu **auto-cicatrisant** : un mouvement qui correspond par **contenu** (date + montant signé + communication) à une transaction existante portant un ancien ID **adopte cette ligne** (`update_column`) au lieu de créer un doublon. **Les rapprochements sont préservés** (on update, on ne supprime jamais). Idempotent.

➡️ **Migration prod = ré-uploader le fichier CODA via le bouton « Importer CODA »** de l'app. Aucun accès serveur, aucun fichier à copier. La réponse expose un compteur `remapped`.

## Vérifications (export réel, 1219 mouvements)

| Contrôle | Résultat |
|---|---|
| Mouvements parsés / importés | 1219 / 1219, 0 sauté |
| Équilibre comptable | `5736,05 + 3459,70 = 9195,75 €` ✅ au centime |
| Dans l'app (Chrome réel) | Triodos affiche **1219** (avant : 579) |
| Auto-cicatrisation (dev) | 560 remappées + 659 créées = 1219 ; ligne rapprochée + son rapprochement survivent ; 2ᵉ import = no-op |

## Tests

Tests de non-régression ajoutés : dédup réf-vide même jour, idempotence réimport, soldes Triodos décalés, **ré-encodage auto sans doublon + rapprochement préservé**. Suite bancaire complète verte (parser + importer + bookkeeper + intégration + matching rules).