### PR TITLE
fix(academy): cascader le soft-delete d'une formation — index 500 (#137)

### DIFF
--- a/app/controllers/api/v1/academy_controller.rb
+++ b/app/controllers/api/v1/academy_controller.rb
@@ -633,9 +633,15 @@ module Api
       def academy_payload
         training_types = Academy::TrainingType.order(:name)
         trainings = Academy::Training.includes(:album, :participant_categories).order(updated_at: :desc)
-        sessions = Academy::TrainingSession.includes(feedbacks: :contact).order(start_date: :asc)
+        # Defense-in-depth (#137) : on ne sérialise que les sessions/inscriptions
+        # rattachées à une formation vivante. `Academy::Training.select(:id)`
+        # respecte le default_scope (deleted_at: nil) → exclut tout orphelin.
+        living_training_ids = Academy::Training.select(:id)
+        sessions = Academy::TrainingSession.where(training_id: living_training_ids)
+          .includes(feedbacks: :contact).order(start_date: :asc)
         locations = Academy::TrainingLocation.order(:name)
         registrations = Academy::TrainingRegistration
+          .where(training_id: living_training_ids)
           .includes(
             registration_items: :participant_category,
             registration_packs: { pack: { pack_items: :participant_category } },

--- a/app/models/academy/training.rb
+++ b/app/models/academy/training.rb
@@ -29,6 +29,24 @@ module Academy
     validates :vat_rate, numericality: { greater_than_or_equal_to: 0, less_than: 100 }
     validates :deposit_amount, numericality: { greater_than_or_equal_to: 0 }
 
+    # Soft-delete en cascade (#137). `SoftDeletable#soft_delete!` fait un
+    # `update_column` qui saute les callbacks : `dependent: :destroy` ne
+    # s'exécute donc pas, et les enfants (inscriptions, sessions, packs…)
+    # deviennent orphelins — leur parent masqué par le default_scope. Ces
+    # orphelins cassaient l'index Academy (500). On masque explicitement les
+    # enfants SoftDeletable avant de masquer la formation.
+    def soft_delete!
+      transaction do
+        sessions.each(&:soft_delete!)
+        registrations.each(&:soft_delete!)
+        documents.each(&:soft_delete!)
+        participant_categories.each(&:soft_delete!)
+        packs.each(&:soft_delete!)
+        album&.soft_delete!
+        super
+      end
+    end
+
     def price_excl_vat
       vat_rate.to_f > 0 ? (price / (1 + vat_rate / 100.0)).round(2) : price
     end

--- a/app/models/academy/training_registration.rb
+++ b/app/models/academy/training_registration.rb
@@ -36,6 +36,10 @@ module Academy
       line_total = items_total + packs_total
       return line_total if line_total.positive?
 
+      # Inscription orpheline : sa formation a été soft-deleted (default_scope
+      # → `training` est nil). On ne lève pas, on renvoie 0.0 (#137).
+      return 0.0 unless training
+
       modern_pricing = training.participant_categories.any? || training.packs.any?
       modern_pricing ? 0.0 : training.price.to_f
     end

--- a/test/integration/academy_training_soft_delete_test.rb
+++ b/test/integration/academy_training_soft_delete_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+# Régression #137 : supprimer une formation peuplée doit cascader le soft-delete
+# à ses enfants (sessions, inscriptions, …) pour éviter les orphelins qui
+# cassaient l'index Academy (500 via computed_expected_amount sur training nil).
+class AcademyTrainingSoftDeleteTest < ActionDispatch::IntegrationTest
+  setup do
+    @type = Academy::TrainingType.create!(name: "Stage-#{SecureRandom.hex(3)}", description: 'Intro')
+    @training = Academy::Training.create!(training_type: @type, title: 'Taille douce', status: 'registrations_open')
+    @category = Academy::ParticipantCategory.create!(training: @training, label: 'Adulte', price: 45.0, max_spots: 10)
+    @session = Academy::TrainingSession.create!(
+      training: @training, start_date: 1.week.from_now, end_date: 1.week.from_now + 1.day, topic: 'Jour 1'
+    )
+    @registration = Academy::TrainingRegistration.create!(
+      training: @training, contact_name: 'Alice Dupont',
+      payment_status: 'pending', registered_at: Time.current, carpooling: 'none'
+    )
+  end
+
+  test 'destroying a training cascades the soft-delete to its children' do
+    delete "/api/v1/academy/trainings/#{@training.id}", as: :json
+    assert_response :no_content
+
+    assert Academy::Training.with_deleted.find(@training.id).deleted?
+    assert_nil Academy::TrainingSession.find_by(id: @session.id), 'la session doit être masquée'
+    assert_nil Academy::TrainingRegistration.find_by(id: @registration.id), "l'inscription doit être masquée"
+    assert Academy::TrainingSession.with_deleted.find(@session.id).deleted?
+    assert Academy::TrainingRegistration.with_deleted.find(@registration.id).deleted?
+  end
+
+  test 'academy index stays 200 after deleting a populated training' do
+    delete "/api/v1/academy/trainings/#{@training.id}", as: :json
+    assert_response :no_content
+
+    get '/api/v1/academy', as: :json
+    assert_response :success
+
+    payload = JSON.parse(response.body)
+    session_ids = payload['trainingSessions'].map { |s| s['id'] }
+    registration_ids = payload['trainingRegistrations'].map { |r| r['id'] }
+    refute_includes session_ids, @session.id.to_s
+    refute_includes registration_ids, @registration.id.to_s
+  end
+
+  test 'academy index ignores pre-existing orphan children (defense-in-depth)' do
+    # Simule un orphelin legacy : enfant vivant dont le parent est soft-deleted
+    # sans cascade (l'état qui a provoqué le 500 en prod).
+    @training.soft_delete! # cascade masque les enfants…
+    @session.restore!      # … on en « ressuscite » un pour simuler l'orphelin legacy
+    @registration.restore!
+
+    get '/api/v1/academy', as: :json
+    assert_response :success
+
+    payload = JSON.parse(response.body)
+    refute_includes payload['trainingSessions'].map { |s| s['id'] }, @session.id.to_s
+    refute_includes payload['trainingRegistrations'].map { |r| r['id'] }, @registration.id.to_s
+  end
+
+  test 'computed_expected_amount returns 0.0 for an orphan registration' do
+    @training.soft_delete!
+    @registration.restore! # inscription vivante, training soft-deleted → orpheline
+    orphan = Academy::TrainingRegistration.find(@registration.id)
+
+    assert_nil orphan.training, 'le training masqué doit rendre training nil'
+    assert_equal 0.0, orphan.computed_expected_amount
+  end
+end


### PR DESCRIPTION
Closes #137

## Ce que fait la PR

Corrige la cause racine d'un **500 sur l'index Academy** (`GET /api/v1/academy`) survenu en prod le 19/06 après suppression de formations peuplées.

**Le bug :** `DELETE /api/v1/academy/trainings/:id` appelle `SoftDeletable#soft_delete!`, qui fait `update_column(:deleted_at, …)` et **saute les callbacks** → `dependent: :destroy` ne s'exécute pas. Les inscriptions/sessions/packs restent vivants mais leur parent est masqué par le `default_scope` : ils deviennent **orphelins**. L'index charge ces inscriptions, et `computed_expected_amount` appelle `training.participant_categories.any?` sur un `training` devenu `nil` → `NoMethodError` → 500.

**Le correctif (3 couches) :**
1. `Academy::Training#soft_delete!` **cascade** le soft-delete à tous les enfants `SoftDeletable` (sessions, inscriptions, documents, participant_categories, packs, album) dans une transaction, avant de masquer la formation.
2. `Academy::TrainingRegistration#computed_expected_amount` **renvoie `0.0`** si `training` est `nil` (au lieu de lever) — robustesse pour toute inscription orpheline.
3. `academy_payload` **scope** sessions et inscriptions aux formations **vivantes** (`where(training_id: Academy::Training.select(:id))`) — defense-in-depth contre d'éventuels orphelins legacy.

## Tests
- `test/integration/academy_training_soft_delete_test.rb` (nouveau, 4 cas) :
  - suppression d'une formation → cascade : session + inscription masquées (et `with_deleted` confirme le soft-delete) ;
  - **index reste 200** après suppression d'une formation peuplée, sans la session/inscription supprimée ;
  - **orphelin legacy simulé** (enfant ressuscité sous un parent soft-deleted) → ignoré par l'index (defense-in-depth) ;
  - `computed_expected_amount` → `0.0` sur une inscription orpheline, sans exception.
- Vérifs locales **toutes vertes** :
  - Test ciblé : 4 runs, 0 failure.
  - Régression Academy (`academy_categories`, `academy_management`, `academy_closure_readiness`) : 106 runs, 0 failure.
  - Suite d'intégration complète : 603 runs, 0 failure.
- Pas de `rubocop` configuré dans le repo. Aucun changement frontend.

## NON testé
- **Pas de rendu visible** : correctif backend pur (cascade de suppression + sérialisation d'index). Pas de capture d'écran — rien à voir à l'écran.
- **Spec OpenAPI inchangée** : aucun endpoint ajouté/modifié (mêmes signatures pour `DELETE …/trainings/:id` et `GET /api/v1/academy`), seul le comportement interne change → pas de régénération nécessaire.

## Notes
- La récupération prod (soft-delete manuel des orphelins) avait déjà été faite ; cette PR empêche la récidive.
- Hors-scope (conforme à l'issue) : refonte globale de `SoftDeletable`, restauration via l'UI, migration de données.
