### PR TITLE
refactor(academy): drop orphan table academy_announcements (#160)

### DIFF
--- a/db/migrate/20260620130000_drop_academy_announcements.rb
+++ b/db/migrate/20260620130000_drop_academy_announcements.rb
@@ -1,0 +1,22 @@
+class DropAcademyAnnouncements < ActiveRecord::Migration[8.1]
+  # `academy_announcements` was a vestige of a never-completed feature: no model,
+  # association, controller, route, frontend reference, seed or test pointed at it
+  # (verified by grep before this migration). We drop the orphan table and its FK.
+  def change
+    drop_table :academy_announcements do |t|
+      t.text "body", default: "", null: false
+      t.bigint "created_by_id"
+      t.datetime "deleted_at"
+      t.datetime "published_at"
+      t.string "status", default: "to_confirm", null: false
+      t.string "title", default: "", null: false
+      t.bigint "training_id", null: false
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index ["deleted_at"], name: "index_academy_announcements_on_deleted_at"
+      t.index ["published_at"], name: "index_academy_announcements_on_published_at"
+      t.index ["training_id"], name: "index_academy_announcements_on_training_id"
+      t.foreign_key "academy_trainings", column: "training_id"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,25 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_20_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_20_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
-
-  create_table "academy_announcements", force: :cascade do |t|
-    t.text "body", default: "", null: false
-    t.datetime "created_at", null: false
-    t.bigint "created_by_id"
-    t.datetime "deleted_at"
-    t.datetime "published_at"
-    t.string "status", default: "to_confirm", null: false
-    t.string "title", default: "", null: false
-    t.bigint "training_id", null: false
-    t.datetime "updated_at", null: false
-    t.index ["deleted_at"], name: "index_academy_announcements_on_deleted_at"
-    t.index ["published_at"], name: "index_academy_announcements_on_published_at"
-    t.index ["training_id"], name: "index_academy_announcements_on_training_id"
-  end
 
   create_table "academy_holidays", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -2724,7 +2709,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_20_120000) do
     t.index ["member_id"], name: "index_wallets_on_member_id", unique: true
   end
 
-  add_foreign_key "academy_announcements", "academy_trainings", column: "training_id"
   add_foreign_key "academy_participant_categories", "academy_trainings", column: "training_id"
   add_foreign_key "academy_participant_messages", "academy_trainings", column: "training_id"
   add_foreign_key "academy_participant_messages", "contacts"


### PR DESCRIPTION
## Résumé
Supprime la table orpheline `academy_announcements` (vestige d'une feature jamais terminée) et sa FK vers `academy_trainings`.

Vérifié avant ET après : `rg 'academy_announcements|Academy::Announcement'` → aucun résultat hors migration. Pas de modèle, association, contrôleur, route, front, seed ni test.

## Vérifications
- [x] Migration `drop_table` + FK ; `schema.rb` régénéré (table + add_foreign_key supprimés)
- [x] `bin/rails test` vert (936 runs, 0 failures)
- [x] Spec OpenAPI inchangée (aucun endpoint ne touchait cette table)

Closes #160