### PR TITLE
fix(tally): capture short « Nom » label and never lose a lead (#158)

### DIFF
--- a/app/services/tally/project_intake_importer.rb
+++ b/app/services/tally/project_intake_importer.rb
@@ -30,7 +30,11 @@ module Tally
       existing = Design::Project.find_by(tally_submission_id: submission_id)
       return Result.new(project: existing, created: false) if existing
 
+      # Libellés multi-mots spécifiques d'abord (prioritaires), puis le libellé
+      # court « Nom » en égalité stricte (sinon « Prénom » ou « Nom et prénom »
+      # seraient captés à tort). Cf. #158 : le vrai formulaire utilise « Nom ».
       name  = text_for("nom et prénom", "nom et prenom", "votre nom")
+      name  = text_for("nom", exact: true) if name.blank?
       email = text_for("e-mail", "email")
       phone = text_for("téléphone", "telephone")
       street = text_for("rue")
@@ -66,7 +70,10 @@ module Tally
           tally_submission_id: submission_id
         )
 
-        contact_id = Academy::RegistrationContactResolver.call(name: name, email: email, phone: phone)
+        # Nom de repli non-vide : un lead n'est jamais perdu. Sans ce repli,
+        # Contact.create!(name: "") lèverait une validation et ferait un ROLLBACK
+        # total (projet + contact) → 422 renvoyée à Tally. Cf. #158.
+        contact_id = Academy::RegistrationContactResolver.call(name: name.presence || "Demande web", email: email, phone: phone)
         if contact_id
           project.project_clients.create!(contact_id: contact_id, is_primary: true, position: 0)
           project.sync_primary_client!
@@ -77,15 +84,26 @@ module Tally
 
     # === Résolution des champs Tally ===
 
-    def field_by_label(*keywords)
-      @fields.find do |f|
-        label = utf8(f[:label]).downcase
-        keywords.any? { |k| label.include?(k.downcase) }
+    # Recherche d'un champ par libellé, **en priorité par mot-clé** : on parcourt
+    # les mots-clés dans l'ordre donné et on renvoie le premier champ qui matche
+    # le mot-clé courant. Les libellés spécifiques l'emportent ainsi sur les
+    # génériques (ex. « Nom et prénom » avant le « Nom » nu).
+    # `exact: true` exige une égalité stricte du libellé — indispensable pour le
+    # libellé court « Nom » afin de ne capter ni « Prénom » ni « Nom et prénom ».
+    def field_by_label(*keywords, exact: false)
+      keywords.each do |keyword|
+        k = utf8(keyword).downcase.strip
+        match = @fields.find do |f|
+          label = utf8(f[:label]).downcase.strip
+          exact ? label == k : label.include?(k)
+        end
+        return match if match
       end
+      nil
     end
 
-    def text_for(*keywords)
-      field = field_by_label(*keywords)
+    def text_for(*keywords, exact: false)
+      field = field_by_label(*keywords, exact: exact)
       field ? display_value(field) : ""
     end
 

--- a/test/integration/tally_intake_test.rb
+++ b/test/integration/tally_intake_test.rb
@@ -135,4 +135,67 @@ class TallyIntakeTest < ActionDispatch::IntegrationTest
          headers: { 'CONTENT_TYPE' => 'text/plain' }
     assert_response :bad_request
   end
+
+  # === #158 : résolution robuste du nom + lead jamais perdu ===
+
+  def payload_with(fields, submission_id: 'sub-x', form_id: 'w77j70')
+    {
+      eventType: 'FORM_RESPONSE',
+      data: { submissionId: submission_id, responseId: "resp-#{submission_id}", formId: form_id, fields: fields }
+    }.to_json
+  end
+
+  # Cas exact qui plantait en prod (Sentry 7561838370) : libellé court « Nom ».
+  test 'short "Nom" label is captured and creates project + named primary contact' do
+    fields = [
+      { label: 'Nom', type: 'INPUT_TEXT', value: 'Carl' },
+      { label: 'Votre adresse e-mail', type: 'INPUT_EMAIL', value: 'onthespiderweb@gmail.com' }
+    ]
+    assert_difference ['Design::Project.count', 'Contact.count'], 1 do
+      post_webhook(payload_with(fields, submission_id: 'sub-nom'))
+    end
+    assert_response :success
+    project = Design::Project.find_by(tally_submission_id: 'sub-nom')
+    assert_equal 'Carl', project.client_name
+    assert_equal 'Carl', project.primary_client_contact.name
+  end
+
+  # Les libellés multi-mots restent prioritaires sur un champ « Prénom ».
+  test 'multi-word name label keeps priority over a bare "Prénom" field' do
+    fields = [
+      { label: 'Prénom', type: 'INPUT_TEXT', value: 'Bob' },
+      { label: 'Nom et prénom', type: 'INPUT_TEXT', value: 'Alice Martin' },
+      { label: 'Votre adresse e-mail', type: 'INPUT_EMAIL', value: 'alice@example.com' }
+    ]
+    post_webhook(payload_with(fields, submission_id: 'sub-prio'))
+    assert_response :success
+    assert_equal 'Alice Martin', Design::Project.find_by(tally_submission_id: 'sub-prio').client_name
+  end
+
+  # Un champ « Prénom » seul ne doit jamais être capté comme nom.
+  test 'a "Prénom" field alone is never captured as the name' do
+    fields = [
+      { label: 'Prénom', type: 'INPUT_TEXT', value: 'Bob' },
+      { label: 'Votre adresse e-mail', type: 'INPUT_EMAIL', value: 'bob@example.com' }
+    ]
+    post_webhook(payload_with(fields, submission_id: 'sub-prenom'))
+    assert_response :success
+    refute_equal 'Bob', Design::Project.find_by(tally_submission_id: 'sub-prenom').client_name
+  end
+
+  # Garantie anti-perte de lead : nom non résolu + email présent → tout est créé.
+  test 'unresolved name label + email present still creates project AND contact' do
+    fields = [
+      { label: 'Champ inconnu', type: 'INPUT_TEXT', value: 'peu importe' },
+      { label: 'Votre adresse e-mail', type: 'INPUT_EMAIL', value: 'lead@example.com' }
+    ]
+    assert_difference ['Design::Project.count', 'Contact.count'], 1 do
+      post_webhook(payload_with(fields, submission_id: 'sub-noname'))
+    end
+    assert_response :success
+    contact = Design::Project.find_by(tally_submission_id: 'sub-noname').primary_client_contact
+    assert_not_nil contact
+    assert contact.name.present?, 'le contact doit recevoir un nom de repli non-vide'
+    assert_equal 'lead@example.com', contact.email
+  end
 end


### PR DESCRIPTION
## Cause racine
Le webhook Tally résolvait le nom via libellés multi-mots uniquement. Le vrai formulaire utilise le libellé court **« Nom »** → `label.include?` échouait, `name=""`, puis `Contact.create!(name:"")` levait une validation → **ROLLBACK total** dans la transaction → **422 + lead perdu** (Sentry 7561838370, 19/06).

## Correctif
- `field_by_label` devient **prioritaire par mot-clé** (libellés spécifiques d'abord) + mode `exact:` pour capter « Nom » sans attraper « Prénom » ni « Nom et prénom ».
- **Nom de repli non-vide** passé au resolver de contact → un lead n'est **jamais** perdu (projet + contact créés même sans nom résolu).

## Tests (4 ajoutés)
- [x] Libellé réel `Nom` → projet + contact primaire `name == 'Carl'`, 200
- [x] Multi-mots prioritaire sur un champ `Prénom`
- [x] `Prénom` seul jamais capté comme nom
- [x] Nom inconnu + email présent → projet + contact créés (repli non-vide), 200
- [x] Suite complète verte (940 runs, 0 failures) ; idempotence/signature/formId inchangés

Closes #158