### PR TITLE
feat(my-semisto): WhatsApp contact widget on Academy pages (#40)

### DIFF
--- a/app/frontend/my-semisto/components/WhatsAppContactWidget.jsx
+++ b/app/frontend/my-semisto/components/WhatsAppContactWidget.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { MessageCircle } from 'lucide-react'
+
+// Widget de contact WhatsApp Business (#40) — V1 simple : lien profond wa.me
+// pré-rempli, sans API. Le message reprend l'activité concernée quand on en
+// passe une (page d'une activité), sinon un message générique (page Académie).
+//
+// TODO #40 : remplacer par le numéro WhatsApp Business dédié Semisto Academy
+// quand il sera créé (cf. issue #42 chatbot). Pour l'instant : Les 4 Sources.
+const WHATSAPP_NUMBER = '32455136142'
+
+export default function WhatsAppContactWidget({ activityTitle = null, className = '' }) {
+  const message = activityTitle
+    ? `Bonjour, j'ai une question concernant l'activité « ${activityTitle} ».`
+    : "Bonjour, j'ai une question concernant les activités Semisto Academy."
+  const href = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(message)}`
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:brightness-95 ${className}`}
+      style={{ backgroundColor: '#25D366' }}
+    >
+      <MessageCircle size={16} />
+      Une question ? Contactez-nous sur WhatsApp
+    </a>
+  )
+}

--- a/app/frontend/pages/MySemisto/Academy.jsx
+++ b/app/frontend/pages/MySemisto/Academy.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { GraduationCap, Loader2, BookOpen, Zap, Clock } from 'lucide-react'
 import MySemistoShell from '../../my-semisto/components/MySemistoShell'
 import TrainingCard from '../../my-semisto/components/TrainingCard'
+import WhatsAppContactWidget from '../../my-semisto/components/WhatsAppContactWidget'
 import { myApiRequest } from '../../my-semisto/lib/api'
 import { myPath, myApiPath } from '../../my-semisto/lib/paths'
 
@@ -74,6 +75,9 @@ export default function Academy() {
         <p className="text-sm text-stone-500 ml-12">
           Des ressources mises à ta disposition par l'équipe et les participants
         </p>
+        <div className="ml-12 mt-4">
+          <WhatsAppContactWidget />
+        </div>
         <hr className="my-section-divider mt-5" />
       </div>
 

--- a/app/frontend/pages/MySemisto/TrainingDetail.jsx
+++ b/app/frontend/pages/MySemisto/TrainingDetail.jsx
@@ -9,6 +9,7 @@ import MySemistoShell from '../../my-semisto/components/MySemistoShell'
 import DocumentList, { DocumentItem } from '../../my-semisto/components/DocumentList'
 import DocumentUploadForm from '../../my-semisto/components/DocumentUploadForm'
 import CarpoolingSection from '../../my-semisto/components/CarpoolingSection'
+import WhatsAppContactWidget from '../../my-semisto/components/WhatsAppContactWidget'
 import SessionPhotoAlbum from '../../my-semisto/components/SessionPhotoAlbum'
 import SessionFeedbackForm from '../../my-semisto/components/SessionFeedbackForm'
 import { myApiRequest } from '../../my-semisto/lib/api'
@@ -255,6 +256,11 @@ export default function TrainingDetail() {
               <CarpoolingSection trainingId={trainingId} />
             </div>
           )}
+
+          {/* Contact WhatsApp (#40) — message pré-rempli avec l'activité concernée */}
+          <div className="flex justify-center pt-2">
+            <WhatsAppContactWidget activityTitle={training.title} />
+          </div>
         </div>
       )}
     </MySemistoShell>


### PR DESCRIPTION
## Widget WhatsApp (V1 simple)
Lien profond **wa.me pré-rempli**, sans API :
- **Page Académie MySemisto** : message générique.
- **Détail d'une activité** : message pré-rempli avec **l'activité concernée**.

Composant réutilisable `WhatsAppContactWidget`.

## ⚠️ Numéro à confirmer
Numéro provisoire = **Les 4 Sources** (`32455136142`), isolé dans une constante en haut du composant. À remplacer par le numéro **WhatsApp Business dédié** Semisto Academy quand il sera créé (cf. #42). Hors scope : l'API WhatsApp Business (V2).

## Vérifications
- [x] `tsc --noEmit` OK ; ESLint 0 erreur (widget propre)
- [x] Pas d'endpoint touché → spec OpenAPI inchangée
- [ ] ⚠️ Vérif visuelle/manuelle (clic → WhatsApp) non effectuée : env de dev local non réinitialisable cette session. Logique du lien vérifiée par lecture.

Closes #40