### PR TITLE
feat(academy): MySemisto link in registration confirmation email (#39)

### DIFF
--- a/app/mailers/academy_mailer.rb
+++ b/app/mailers/academy_mailer.rb
@@ -18,6 +18,14 @@ class AcademyMailer < ApplicationMailer
     @payment_amount = registration.payment_amount.to_f
     @payment_method = payment_method
 
+    # Lien MySemisto (#39) — magic-link basé sur le contact (login par code
+    # email, pas de doublon de compte). Mène à la page de l'activité, où
+    # l'inscrit voit les détails et le covoiturage des autres inscrits.
+    contact = registration.contact ||
+              (registration.contact_email.present? && Contact.find_by("LOWER(email) = ?", registration.contact_email.downcase)) ||
+              nil
+    @my_semisto_url = participant_session_url(@training, contact)
+
     attachments.inline["academy-logo.png"] = File.read(
       Rails.root.join("public/icons/academy.png")
     )

--- a/app/views/academy_mailer/registration_confirmation.html.erb
+++ b/app/views/academy_mailer/registration_confirmation.html.erb
@@ -206,6 +206,28 @@
   </table>
 <% end %>
 
+<!-- MySemisto CTA (#39) -->
+<% if @my_semisto_url.present? %>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom: 12px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellpadding="0" cellspacing="0">
+          <tr>
+            <td style="background-color: #B01A19; border-radius: 10px;">
+              <a href="<%= @my_semisto_url %>" style="display: inline-block; padding: 16px 32px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 10px;">
+                Voir mon activit&eacute; sur MySemisto
+              </a>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+  <p style="margin: 0 0 28px; text-align: center; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 13px; line-height: 1.6; color: #6b7280;">
+    Retrouve tous les d&eacute;tails pratiques et le covoiturage avec les autres inscrit&middot;es.
+  </p>
+<% end %>
+
 <!-- Closing -->
 <p style="margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 15px; line-height: 1.7; color: #374151;">
   &Agrave; tr&egrave;s bient&ocirc;t&nbsp;!

--- a/app/views/academy_mailer/registration_confirmation.text.erb
+++ b/app/views/academy_mailer/registration_confirmation.text.erb
@@ -52,6 +52,11 @@ Méthode de paiement : <%= @payment_method %>
 Solde restant : <%= format_eur_text(@payment_amount - @amount_paid) %>
 Une demande de paiement pour le solde te sera envoyée ultérieurement par l'équipe Semisto Academy.
 <% end %>
+<% if @my_semisto_url.present? %>
+
+Voir mon activité sur MySemisto (détails pratiques + covoiturage avec les autres inscrit·es) :
+<%= @my_semisto_url %>
+<% end %>
 
 À très bientôt !
 

--- a/test/mailers/academy_mailer_test.rb
+++ b/test/mailers/academy_mailer_test.rb
@@ -19,4 +19,33 @@ class AcademyMailerTest < ActionMailer::TestCase
     assert_includes Array(mail.cc), 'formations@semisto.org'
     assert_match(/documents/i, mail.subject)
   end
+
+  test 'registration_confirmation embeds a MySemisto magic-link to the activity (#39)' do
+    contact = Contact.create!(contact_type: 'person', name: 'Marie', email: 'marie@test.be')
+    registration = Academy::TrainingRegistration.create!(
+      training: @training, contact: contact, contact_name: 'Marie',
+      contact_email: 'marie@test.be', payment_status: 'paid', registered_at: Time.current
+    )
+
+    with_env('MY_SEMISTO_HOST' => 'my.semisto.test') do
+      mail = AcademyMailer.registration_confirmation(registration)
+      body = mail.body.encoded
+
+      # Lien magic-link basé sur le contact (login par code, pas de doublon),
+      # pointant vers la page de l'activité (détails + covoiturage).
+      assert_match %r{my\.semisto\.test/api/v1/auth/verify\?token=}, body
+      assert_match %r{redirect=.*academy.*#{@training.id}}, body
+      assert_match(/MySemisto/i, body)
+    end
+  end
+
+  private
+
+  def with_env(values)
+    previous = {}
+    values.each { |k, v| previous[k] = ENV[k]; ENV[k] = v }
+    yield
+  ensure
+    previous.each { |k, v| v.nil? ? ENV.delete(k) : (ENV[k] = v) }
+  end
 end


### PR DESCRIPTION
## Contenu
L'email de confirmation d'inscription contient désormais un **lien vers MySemisto**, sur la page de l'activité — où l'inscrit voit les **détails** et le **covoiturage** des autres inscrits.

- Lien = **magic-link basé sur le contact** (`message_verifier(:contact_login)`, 21 j) → login par code email, **aucun doublon de compte**. Réutilise `participant_session_url`, déjà employé par le rappel de session.
- Bouton dans le template **HTML** + lien dans le template **texte** (rendus seulement si le lien est disponible).

Le covoiturage et les détails vivent déjà sur la page `/academy/:id` de MySemisto (relais anonyme en place) — l'email ne fait que pointer dessus (approche légère).

## Vérifications
- [x] Test mailer : la confirmation embarque le magic-link `/api/v1/auth/verify?token=…&redirect=…/academy/<id>`
- [x] Pas de doublon de compte (login par contact via token signé)
- [x] Suite complète verte (962 runs, 0 failures) ; pas d'endpoint touché → spec OpenAPI inchangée

Closes #39