### PR TITLE
hotfix(db): guard drop_table academy_announcements with if_exists — prod migrations stuck (#160)

### DIFF
--- a/db/migrate/20260620130000_drop_academy_announcements.rb
+++ b/db/migrate/20260620130000_drop_academy_announcements.rb
@@ -2,8 +2,14 @@ class DropAcademyAnnouncements < ActiveRecord::Migration[8.1]
   # `academy_announcements` was a vestige of a never-completed feature: no model,
   # association, controller, route, frontend reference, seed or test pointed at it
   # (verified by grep before this migration). We drop the orphan table and its FK.
+  #
+  # `if_exists: true` (hotfix) : the table is present in dev/test (loaded from
+  # schema.rb) but was NEVER created in production — it had no creating migration
+  # (schema.rb drift). Without the guard the drop raised PG::UndefinedTable in
+  # prod and CANCELLED every later migration (incl. add kind to design_projects),
+  # crashing all Design::Project loads. The guard makes it a safe no-op when absent.
   def change
-    drop_table :academy_announcements do |t|
+    drop_table :academy_announcements, if_exists: true do |t|
       t.text "body", default: "", null: false
       t.bigint "created_by_id"
       t.datetime "deleted_at"


### PR DESCRIPTION
## 🚨 Incident production
Depuis le déploiement du batch (release `fec2006`), `db:migrate` échoue en prod :
```
PG::UndefinedTable: table "academy_announcements" does not exist
db/migrate/20260620130000_drop_academy_announcements.rb:6
```
La table existe en dev/test (chargée via `schema.rb`) mais **n'a jamais été créée en prod** — aucune migration ne la créait (**dérive de schema.rb**, déjà signalée). Le drop nu a levé l'erreur et **annulé toutes les migrations suivantes**, dont `add_kind_to_design_projects`. Résultat : `design_projects.kind` absent + code `enum :kind` déployé → **RuntimeError sur chaque `Design::Project`** → 500 sur ProjectsController#index/board, TasksController#my_tasks/my_planning, LabManagement#overview (TERRANOVA-49/4A/4B/4C/4D).

## Correctif
`drop_table :academy_announcements, if_exists: true` → no-op sûr quand la table est absente (prod), drop normal sinon (dev/test). La migration n'avait jamais été enregistrée (rollback), elle re-tourne au prochain déploiement et laisse passer le reste du batch.

## Vérification (prod-parity)
- [x] `drop_table if_exists: true` no-ope quand la table est absente (le `drop` nu lève bien l'erreur prod)
- [x] **migrate from scratch** sur une DB neuve (= build prod) → toute la chaîne passe ; `kind` + `design_calendars` + `reactions` + `event_action_items` créés ; `academy_announcements` absente sans crash

Fixes TERRANOVA-48